### PR TITLE
Add ReadyTrader CRYPTO plugin

### DIFF
--- a/plugins/readytrader_crypto/index.yaml
+++ b/plugins/readytrader_crypto/index.yaml
@@ -1,0 +1,7 @@
+title: ReadyTrader Crypto
+description: Agent Zero plugin for the ReadyTrader-Crypto MCP server. Gives your agent access to crypto market data, risk validation, backtesting, and paper/live trading.
+github: https://github.com/up2itnow0822/a0-readytrader-crypto-plugin
+tags:
+  - tools
+  - trading
+  - finance


### PR DESCRIPTION
Adds the ReadyTrader CRYPTO plugin to the index.

This plugin connects Agent Zero to the [ReadyTrader-CRYPTO](https://github.com/up2itnow0822/ReadyTrader-CRYPTO) MCP server for crypto market data, risk management, backtesting, and paper/live trading.

Repo: https://github.com/up2itnow0822/a0-readytrader-crypto-plugin