### PR TITLE
Add ReadyTrader FOREX plugin

### DIFF
--- a/plugins/readytrader_forex/index.yaml
+++ b/plugins/readytrader_forex/index.yaml
@@ -1,0 +1,7 @@
+title: ReadyTrader FOREX
+description: Agent Zero plugin for the ReadyTrader-FOREX MCP server. Gives your agent access to forex market data, risk validation, backtesting, and paper/live trading.
+github: https://github.com/up2itnow0822/a0-readytrader-forex-plugin
+tags:
+  - tools
+  - trading
+  - finance


### PR DESCRIPTION
Adds the ReadyTrader FOREX plugin to the index.

This plugin connects Agent Zero to the [ReadyTrader-FOREX](https://github.com/up2itnow0822/ReadyTrader-FOREX) MCP server for forex market data, risk management, backtesting, and paper/live trading.

Repo: https://github.com/up2itnow0822/a0-readytrader-forex-plugin