### PR TITLE
Add ReadyTrader STOCKS plugin

### DIFF
--- a/plugins/readytrader_stocks/index.yaml
+++ b/plugins/readytrader_stocks/index.yaml
@@ -1,0 +1,7 @@
+title: ReadyTrader Stocks
+description: Agent Zero plugin for the ReadyTrader-Stocks MCP server. Gives your agent access to equities market data, risk validation, backtesting, and paper/live trading.
+github: https://github.com/up2itnow0822/a0-readytrader-stocks-plugin
+tags:
+  - tools
+  - trading
+  - finance


### PR DESCRIPTION
Adds the ReadyTrader STOCKS plugin to the index.

This plugin connects Agent Zero to the [ReadyTrader-STOCKS](https://github.com/up2itnow0822/ReadyTrader-STOCKS) MCP server for stocks market data, risk management, backtesting, and paper/live trading.

Repo: https://github.com/up2itnow0822/a0-readytrader-stocks-plugin