### PR TITLE
Add screenshots support and authors indexing; update validation and index generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Each plugin submission is a single folder (unique plugin name) containing:
 - **Optional thumbnail image** (`.png`, `.jpeg`/`.jpg`, or `.webp`)
   - **Square aspect ratio**
   - **Max size: 20 KB**
+- **Optional screenshots** under `screenshots/`
+  - Up to **3 screenshots**
+  - File names must be numeric: **`1`**, **`2`**, **`3`** (with image extension)
+  - Allowed formats: `.png`, `.jpg`/`.jpeg`, `.webp`
+  - **Max size: 250 KB per screenshot**
 
 This repository is an index only: `plugin.yaml` points to the plugin's own repository.
 
@@ -39,7 +44,7 @@ PRs are automatically checked for:
 
 - **Structure**
   - Exactly one plugin folder per PR under `plugins/<your-plugin-name>/`
-  - No extra files (only `plugin.yaml` and an optional thumbnail)
+  - No extra files (only `plugin.yaml`, an optional thumbnail, and optional files in `screenshots/`)
 - **`plugin.yaml` rules**
   - Only allowed fields: `title`, `description`, `github`, `tags`
   - Required fields: `title`, `description`, `github`
@@ -51,6 +56,12 @@ PRs are automatically checked for:
   - Must be named `thumbnail.<ext>`
   - Must be square and <= 20 KB
   - Allowed formats: `.png`, `.jpg`/`.jpeg`, `.webp`
+- **Screenshot rules (optional)**
+  - Must be under `screenshots/`
+  - Up to 3 files total
+  - Filenames must be `1.<ext>`, `2.<ext>`, `3.<ext>`
+  - Allowed formats: `.png`, `.jpg`/`.jpeg`, `.webp`
+  - Max size per file: 250 KB
 
 ### Folder structure
 
@@ -58,6 +69,10 @@ PRs are automatically checked for:
 plugins/<your-plugin-name>/
   plugin.yaml
   thumbnail.png|thumbnail.jpg|thumbnail.jpeg|thumbnail.webp   (optional)
+  screenshots/                                            (optional)
+    1.png|1.jpg|1.jpeg|1.webp
+    2.png|2.jpg|2.jpeg|2.webp
+    3.png|3.jpg|3.jpeg|3.webp
 ```
 
 ### `plugin.yaml` format

--- a/authors/agent0ai/author.yaml
+++ b/authors/agent0ai/author.yaml
@@ -1,0 +1,1 @@
+level: owner

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -15,6 +15,8 @@ from plugin_resolution import (
 )
 
 INDEX_JSON_PATH = REPO_ROOT / "index.json"
+AUTHORS_DIR = REPO_ROOT / "authors"
+ALLOWED_IMAGE_EXTS = (".png", ".jpg", ".jpeg", ".webp")
 
 
 class GenerateIndexError(Exception):
@@ -54,6 +56,15 @@ def _load_index() -> dict[str, Any]:
 def _plugin_exists(plugin_name: str) -> bool:
     plugin_yaml = PLUGINS_DIR / plugin_name / "plugin.yaml"
     return plugin_yaml.exists()
+
+
+def _full_scan_requested() -> bool:
+    plugin_names_env = os.environ.get("PLUGIN_NAMES", "").strip()
+    if plugin_names_env:
+        return False
+
+    before = os.environ.get("BEFORE_SHA", "").strip()
+    return not before or set(before) == {"0"}
 
 
 def _prune_removed_plugins(index: dict[str, Any]) -> int:
@@ -98,6 +109,8 @@ def _index_plugin_entry(plugin_name: str, meta: dict[str, Any]) -> dict[str, Any
         tags = [t for t in tags_val if t.strip()]
     thumb_rel = _thumbnail_rel_path(plugin_name)
     thumb = _repo_file_url(thumb_rel) if isinstance(thumb_rel, str) else None
+    screenshot_rels = _screenshot_rel_paths(plugin_name)
+    screenshots = [_repo_file_url(rel) for rel in screenshot_rels]
     return {
         "title": title,
         "description": description,
@@ -105,6 +118,7 @@ def _index_plugin_entry(plugin_name: str, meta: dict[str, Any]) -> dict[str, Any
         "author": author,
         "tags": tags,
         "thumbnail": thumb,
+        "screenshots": screenshots,
     }
 
 
@@ -132,6 +146,7 @@ def _upsert_index_plugin(
     entry["author"] = generated.get("author")
     entry["tags"] = generated.get("tags")
     entry["thumbnail"] = generated.get("thumbnail")
+    entry["screenshots"] = generated.get("screenshots")
     if discussion_url is not None:
         entry["discussion"] = discussion_url
 
@@ -142,11 +157,72 @@ def _thumbnail_rel_path(plugin_name: str) -> str | None:
     plugin_dir = PLUGINS_DIR / plugin_name
     if not plugin_dir.exists():
         return None
-    for ext in (".png", ".jpg", ".jpeg", ".webp"):
+    for ext in ALLOWED_IMAGE_EXTS:
         p = plugin_dir / f"thumbnail{ext}"
         if p.exists():
             return p.relative_to(REPO_ROOT).as_posix()
     return None
+
+
+def _screenshot_rel_paths(plugin_name: str) -> list[str]:
+    plugin_dir = PLUGINS_DIR / plugin_name
+    screenshots_dir = plugin_dir / "screenshots"
+    if not screenshots_dir.exists() or not screenshots_dir.is_dir():
+        return []
+
+    rel_paths: list[str] = []
+    for filename in ("1", "2", "3"):
+        for ext in ALLOWED_IMAGE_EXTS:
+            p = screenshots_dir / f"{filename}{ext}"
+            if p.exists():
+                rel_paths.append(p.relative_to(REPO_ROOT).as_posix())
+                break
+
+    return rel_paths
+
+
+def _read_authors() -> dict[str, Any]:
+    if not AUTHORS_DIR.exists() or not AUTHORS_DIR.is_dir():
+        return {}
+
+    authors: dict[str, Any] = {}
+    for author_dir in sorted(AUTHORS_DIR.iterdir(), key=lambda x: x.name):
+        if not author_dir.is_dir():
+            continue
+        author_yaml = author_dir / "author.yaml"
+        if not author_yaml.exists():
+            continue
+        try:
+            loaded = yaml.safe_load(author_yaml.read_text(encoding="utf-8"))
+        except Exception as e:
+            _fail(f"Invalid author metadata in {author_yaml.relative_to(REPO_ROOT)}: {e}")
+
+        if not isinstance(loaded, dict):
+            _fail(f"{author_yaml.relative_to(REPO_ROOT)} must contain a YAML mapping/object")
+
+        authors[author_dir.name] = loaded
+
+    return authors
+
+
+def _authors_changed() -> bool:
+    before = os.environ.get("BEFORE_SHA", "").strip()
+    after = os.environ.get("AFTER_SHA", "").strip()
+
+    if not before or not after:
+        return False
+
+    changed = _run(["git", "diff", "--name-only", f"{before}..{after}"]).splitlines()
+    return any(line.strip().startswith("authors/") for line in changed)
+
+
+def _maybe_update_authors(index: dict[str, Any]) -> None:
+    existing = index.get("authors")
+    authors_missing = not isinstance(existing, dict)
+    if not authors_missing and not _authors_changed():
+        return
+
+    index["authors"] = _read_authors()
 
 
 def _repo_file_url(rel_path: str) -> str:
@@ -216,12 +292,23 @@ def main() -> int:
         _fail("GITHUB_REPOSITORY is required")
 
     plugin_names = get_plugin_names()
-    if not plugin_names:
-        print("No plugin changes detected; index left as is.")
-        return 0
 
     index = _load_index()
     index_before = json.dumps(index, sort_keys=True)
+
+    if _full_scan_requested():
+        removed = _prune_removed_plugins(index)
+        if removed:
+            print(f"Pruned {removed} removed plugins during full scan")
+
+    if not plugin_names:
+        _maybe_update_authors(index)
+        index_after = json.dumps(index, sort_keys=True)
+        if index_after != index_before:
+            _save_index(index)
+            print(f"Updated {INDEX_JSON_PATH.name}")
+        print("No plugin changes detected; index left as is.")
+        return 0
 
     updated = 0
 
@@ -244,6 +331,8 @@ def main() -> int:
         discussion_url = existing_entry.get("discussion") if isinstance(existing_entry.get("discussion"), str) else None
         _upsert_index_plugin(index, plugin_name, meta, discussion_url)
         updated += 1
+
+    _maybe_update_authors(index)
 
     index_after = json.dumps(index, sort_keys=True)
     if index_after != index_before:

--- a/scripts/validate_pr.py
+++ b/scripts/validate_pr.py
@@ -20,8 +20,12 @@ ALLOWED_YAML_KEYS = {"title", "description", "github", "tags"}
 REQUIRED_YAML_KEYS = {"title", "description", "github"}
 ALLOWED_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp"}
 MAX_IMAGE_BYTES = 20 * 1024
+MAX_SCREENSHOT_BYTES = 250 * 1024
 MAX_TAGS = 5
 THUMBNAIL_BASENAME = "thumbnail"
+SCREENSHOTS_DIRNAME = "screenshots"
+MAX_SCREENSHOTS = 3
+ALLOWED_SCREENSHOT_BASENAMES = {"1", "2", "3"}
 MAX_TITLE_LENGTH = 50
 MAX_DESCRIPTION_LENGTH = 500
 
@@ -178,6 +182,25 @@ def _validate_thumbnail(image_path: Path) -> None:
         )
 
 
+def _validate_screenshot(image_path: Path) -> None:
+    if image_path.suffix.lower() not in ALLOWED_IMAGE_EXTS:
+        _fail(
+            f"Screenshot must be one of {sorted(ALLOWED_IMAGE_EXTS)}: {image_path.relative_to(REPO_ROOT)}"
+        )
+
+    size = image_path.stat().st_size
+    if size > MAX_SCREENSHOT_BYTES:
+        _fail(
+            f"Screenshot is too large ({size} bytes). Max is {MAX_SCREENSHOT_BYTES} bytes: {image_path.relative_to(REPO_ROOT)}"
+        )
+
+    try:
+        with Image.open(image_path) as _:
+            pass
+    except Exception as e:
+        _fail(f"Screenshot image could not be opened: {image_path.relative_to(REPO_ROOT)}: {e}")
+
+
 def _github_api_get_json(url: str) -> dict:
     token = os.environ.get("GITHUB_TOKEN")
     headers = {
@@ -284,27 +307,53 @@ def main() -> int:
     if plugin_yaml_path not in plugin_files:
         _fail(f"Missing required file in PR head: {plugin_yaml_path}")
 
-    # Validate no extra files and optional thumbnail naming.
+    # Validate no extra files and optional thumbnail/screenshots naming.
     thumbnails: list[str] = []
+    screenshots: list[str] = []
     for f in plugin_files:
-        name = f.split("/")[-1]
+        path_obj = Path(f)
+        name = path_obj.name
         if name == "plugin.yaml":
             continue
-        suffix = Path(name).suffix.lower()
-        if suffix in ALLOWED_IMAGE_EXTS:
-            stem = Path(name).stem.lower()
-            if stem != THUMBNAIL_BASENAME:
+
+        if len(path_obj.parts) == 3 and path_obj.parts[1] == SCREENSHOTS_DIRNAME:
+            suffix = path_obj.suffix.lower()
+            if suffix not in ALLOWED_IMAGE_EXTS:
                 _fail(
-                    f"Thumbnail must be named '{THUMBNAIL_BASENAME}<ext>' (e.g. thumbnail.png). Found: {f}"
+                    f"Screenshot must use one of {sorted(ALLOWED_IMAGE_EXTS)}: {f}"
                 )
-            thumbnails.append(f)
+            if path_obj.stem not in ALLOWED_SCREENSHOT_BASENAMES:
+                _fail(
+                    f"Screenshot filename must be numbered 1, 2, or 3 (example: screenshots/1.png). Found: {f}"
+                )
+            screenshots.append(f)
             continue
+
+        if len(path_obj.parts) == 2:
+            suffix = path_obj.suffix.lower()
+            if suffix in ALLOWED_IMAGE_EXTS:
+                stem = path_obj.stem.lower()
+                if stem != THUMBNAIL_BASENAME:
+                    _fail(
+                        f"Thumbnail must be named '{THUMBNAIL_BASENAME}<ext>' (e.g. thumbnail.png). Found: {f}"
+                    )
+                thumbnails.append(f)
+                continue
+
         _fail(
-            f"Unsupported file in plugin folder: {f}. Only plugin.yaml and an optional thumbnail image are allowed."
+            "Unsupported file in plugin folder: "
+            f"{f}. Only plugin.yaml, an optional thumbnail image, and optional screenshots/1|2|3.<ext> files are allowed."
         )
 
     if len(thumbnails) > 1:
         _fail("At most one thumbnail image is allowed. Found: " + ", ".join(thumbnails))
+
+    if len(screenshots) > MAX_SCREENSHOTS:
+        _fail(f"At most {MAX_SCREENSHOTS} screenshots are allowed. Found: " + ", ".join(screenshots))
+
+    screenshot_numbers = {Path(p).stem for p in screenshots}
+    if len(screenshot_numbers) != len(screenshots):
+        _fail("Duplicate screenshot numbers are not allowed. Use each of 1, 2, 3 at most once.")
 
     plugin_yaml_bytes = _git_show_bytes(head_sha, plugin_yaml_path)
     _validate_yaml_bytes(plugin_yaml_path, plugin_yaml_bytes)
@@ -317,6 +366,19 @@ def main() -> int:
             tmp_path = Path(tmp.name)
         try:
             _validate_thumbnail(tmp_path)
+        finally:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except Exception:
+                pass
+
+    for screenshot_path in screenshots:
+        screenshot_bytes = _git_show_bytes(head_sha, screenshot_path)
+        with tempfile.NamedTemporaryFile(suffix=Path(screenshot_path).suffix, delete=False) as tmp:
+            tmp.write(screenshot_bytes)
+            tmp_path = Path(tmp.name)
+        try:
+            _validate_screenshot(tmp_path)
         finally:
             try:
                 tmp_path.unlink(missing_ok=True)


### PR DESCRIPTION
### Motivation

- Add optional screenshot assets for plugins with clear naming, format, and size constraints so plugin listings can include multiple preview images.  
- Include repository-local author metadata under `authors/` in the generated `index.json` to surface ownership/roles.  
- Update CI validation and index generation to enforce and index the new screenshot and author features deterministically.

### Description

- Updated `README.md` to document `screenshots/` rules (up to 3 files named `1|2|3` with allowed image formats and a 250 KB per-file limit).  
- Extended `scripts/validate_pr.py` to recognize `screenshots/`, added constants `MAX_SCREENSHOT_BYTES`, `MAX_SCREENSHOTS`, and `ALLOWED_SCREENSHOT_BASENAMES`, added `_validate_screenshot`, and validated screenshot naming, formats, and sizes while preserving thumbnail validation.  
- Extended `scripts/generate_index.py` to collect screenshot paths into index entries, added `ALLOWED_IMAGE_EXTS`, implemented `_screenshot_rel_paths`, added author-reading logic `_read_authors`, change detection `_authors_changed`, and `_maybe_update_authors`, and added full-scan/prune behavior via `_full_scan_requested` and pruning in full scans.  
- Added an example author metadata file `authors/agent0ai/author.yaml` with `level: owner` to demonstrate the authors format.

### Testing

- Ran `scripts/validate_pr.py` against example plugin layouts including thumbnail and screenshots and the script exited with code `0` (validation passed).  
- Executed `scripts/generate_index.py` in the repository environment with `GITHUB_REPOSITORY` and refs set and confirmed it produced/updated `index.json` without errors (exit code `0`).  
- Confirmed that CI-style checks (local validation + index generation smoke tests) completed successfully for the modified code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaeb9d7e608332b0e1fba0536f751f)