### PR TITLE
Support remote screenshot URLs, enforce plugin name pattern, and improve validation & discussion handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Each plugin submission is a single folder (unique plugin name) containing:
 - **Optional thumbnail image** (`.png`, `.jpeg`/`.jpg`, or `.webp`)
   - **Square aspect ratio**
   - **Max size: 20 KB**
-- **Optional screenshots** under `screenshots/`
-  - Up to **3 screenshots**
-  - File names must be numeric: **`1`**, **`2`**, **`3`** (with image extension)
-  - Allowed formats: `.png`, `.jpg`/`.jpeg`, `.webp`
-  - **Max size: 250 KB per screenshot**
+- **Optional screenshots** listed in `plugin.yaml` as full URLs
+  - Up to **5 screenshot URLs**
+  - Allowed formats by URL path extension: `.png`, `.jpg`/`.jpeg`, `.webp`
+  - URL max length: **200 characters**
+  - Validator checks each URL is reachable and file size is <= **2 MB**
 
 This repository is an index only: `plugin.yaml` points to the plugin's own repository.
 
@@ -30,54 +30,53 @@ If your PR keeps failing checks and has no activity for 7+ days, it may be autom
 - **One plugin per PR**
   - Your PR must add exactly **one** new top-level subfolder for your plugin.
 - **Unique folder name**
-  - Use a unique, stable folder name (recommended: short, lowercase, `kebab-case`).
+  - Use a unique, stable folder name with lowercase letters, numbers, and underscores only (regex: `^[a-z0-9_]+$`).
 - **Reserved names**
   - Folders starting with `_` are reserved for project/internal use (examples, templates, etc.) and are **not visible in Agent Zero**. Do not submit community plugins with a leading underscore.
 - **Required metadata**
   - All required fields in `plugin.yaml` must be present and non-empty.
 - **Optional metadata**
-  - The only optional field is **`tags`**.
+  - Optional fields are **`tags`** and **`screenshots`**.
 
 ### Automated validation (CI)
 
 PRs are automatically checked for:
 
 - **Structure**
-  - Exactly one plugin folder per PR under `plugins/<your-plugin-name>/`
-  - No extra files (only `plugin.yaml`, an optional thumbnail, and optional files in `screenshots/`)
+  - Exactly one plugin folder per PR under `plugins/<your_plugin_name>/`
+  - Plugin folder name must match `^[a-z0-9_]+$` (lowercase letters, numbers, underscores only)
+  - No extra files (only `plugin.yaml` and an optional thumbnail image)
 - **`plugin.yaml` rules**
-  - Only allowed fields: `title`, `description`, `github`, `tags`
+  - Only allowed fields: `title`, `description`, `github`, `tags`, `screenshots`
   - Required fields: `title`, `description`, `github`
+  - Total file length max: 2000 characters
   - `title` max length: 50 characters
   - `description` max length: 500 characters
   - `github` must be a GitHub repository URL that exists and contains `plugin.yaml` at the repository root
-  - `tags` (if present) must be a list of strings, up to 5
+  - `tags` (if present) must be a list of strings, up to 5, max 30 chars per tag
+  - `screenshots` (if present) must be a list of up to 5 full `http(s)` URLs
 - **Thumbnail rules (optional)**
   - Must be named `thumbnail.<ext>`
   - Must be square and <= 20 KB
   - Allowed formats: `.png`, `.jpg`/`.jpeg`, `.webp`
-- **Screenshot rules (optional)**
-  - Must be under `screenshots/`
-  - Up to 3 files total
-  - Filenames must be `1.<ext>`, `2.<ext>`, `3.<ext>`
-  - Allowed formats: `.png`, `.jpg`/`.jpeg`, `.webp`
-  - Max size per file: 250 KB
+- **Screenshot URL rules (optional)**
+  - Must be provided in `plugin.yaml` as full URLs (no local screenshot files in this repo)
+  - Up to 5 URLs
+  - URL length max: 200 characters each
+  - URL path extension must be one of: `.png`, `.jpg`/`.jpeg`, `.webp`
+  - Each URL must be reachable and content size must be <= 2 MB
 
 ### Folder structure
 
 ```text
-plugins/<your-plugin-name>/
+plugins/<your_plugin_name>/
   plugin.yaml
   thumbnail.png|thumbnail.jpg|thumbnail.jpeg|thumbnail.webp   (optional)
-  screenshots/                                            (optional)
-    1.png|1.jpg|1.jpeg|1.webp
-    2.png|2.jpg|2.jpeg|2.webp
-    3.png|3.jpg|3.jpeg|3.webp
 ```
 
 ### `plugin.yaml` format
 
-See `plugins/example1/plugin.yaml` for the reference format.
+See `plugins/_example1/plugin.yaml` for the reference format.
 
 Required fields:
 
@@ -87,7 +86,8 @@ Required fields:
 
 Optional fields:
 
-- **`tags`**: List of tags (recommended list: [`TAGS.md`](./TAGS.md), up to 5 tags)
+- **`tags`**: List of tags (recommended list: [`TAGS.md`](./TAGS.md), up to 5 tags, max 30 chars each)
+- **`screenshots`**: List of full screenshot image URLs (up to 5, each <= 200 chars)
 
 Example:
 
@@ -98,6 +98,9 @@ github: https://github.com/agentzero/a0-plugin-example
 tags:
   - example
   - template
+screenshots:
+  - https://example.com/images/preview-home.png
+  - https://cdn.example.org/a0-plugin/flow.webp
 ```
 
 ## Recommended tags

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -12,6 +12,7 @@ from plugin_resolution import (
     REPO_ROOT,
     PluginResolutionError,
     get_plugin_names,
+    is_valid_plugin_dirname,
 )
 
 INDEX_JSON_PATH = REPO_ROOT / "index.json"
@@ -76,7 +77,11 @@ def _prune_removed_plugins(index: dict[str, Any]) -> int:
     for plugin_name in list(plugins.keys()):
         if not isinstance(plugin_name, str):
             continue
-        if not plugin_name or plugin_name.startswith("_"):
+        if not plugin_name:
+            continue
+        if not is_valid_plugin_dirname(plugin_name):
+            del plugins[plugin_name]
+            removed += 1
             continue
         if not _plugin_exists(plugin_name):
             del plugins[plugin_name]
@@ -109,8 +114,10 @@ def _index_plugin_entry(plugin_name: str, meta: dict[str, Any]) -> dict[str, Any
         tags = [t for t in tags_val if t.strip()]
     thumb_rel = _thumbnail_rel_path(plugin_name)
     thumb = _repo_file_url(thumb_rel) if isinstance(thumb_rel, str) else None
-    screenshot_rels = _screenshot_rel_paths(plugin_name)
-    screenshots = [_repo_file_url(rel) for rel in screenshot_rels]
+    screenshots_val = meta.get("screenshots")
+    screenshots: list[str] = []
+    if isinstance(screenshots_val, list) and all(isinstance(s, str) for s in screenshots_val):
+        screenshots = [s.strip() for s in screenshots_val if s.strip()]
     return {
         "title": title,
         "description": description,
@@ -163,22 +170,6 @@ def _thumbnail_rel_path(plugin_name: str) -> str | None:
             return p.relative_to(REPO_ROOT).as_posix()
     return None
 
-
-def _screenshot_rel_paths(plugin_name: str) -> list[str]:
-    plugin_dir = PLUGINS_DIR / plugin_name
-    screenshots_dir = plugin_dir / "screenshots"
-    if not screenshots_dir.exists() or not screenshots_dir.is_dir():
-        return []
-
-    rel_paths: list[str] = []
-    for filename in ("1", "2", "3"):
-        for ext in ALLOWED_IMAGE_EXTS:
-            p = screenshots_dir / f"{filename}{ext}"
-            if p.exists():
-                rel_paths.append(p.relative_to(REPO_ROOT).as_posix())
-                break
-
-    return rel_paths
 
 
 def _read_authors() -> dict[str, Any]:

--- a/scripts/plugin_resolution.py
+++ b/scripts/plugin_resolution.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import NoReturn
@@ -6,6 +7,7 @@ from typing import NoReturn
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PLUGINS_DIR = REPO_ROOT / "plugins"
 DEFAULT_MAX_PLUGINS = 1000
+PLUGIN_DIRNAME_PATTERN = re.compile(r"^[a-z0-9_]+$")
 
 
 class PluginResolutionError(Exception):
@@ -21,6 +23,10 @@ def _run(cmd: list[str]) -> str:
     return out.decode("utf-8", errors="replace")
 
 
+def is_valid_plugin_dirname(plugin_name: str) -> bool:
+    return bool(PLUGIN_DIRNAME_PATTERN.fullmatch(plugin_name))
+
+
 def _is_zero_sha(sha: str | None) -> bool:
     if not sha:
         return True
@@ -29,13 +35,43 @@ def _is_zero_sha(sha: str | None) -> bool:
 
 
 def _git_diff_names(before: str, after: str) -> list[str]:
-    raw = _run(["git", "diff", "--name-only", f"{before}..{after}"])
-    return [line.strip() for line in raw.splitlines() if line.strip()]
+    raw = _run(["git", "diff", "--name-status", f"{before}..{after}"])
+    paths: list[str] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        for p in parts[1:]:
+            p = p.strip()
+            if p:
+                paths.append(p)
+    return paths
 
 
 def _git_all_plugin_paths(commit: str) -> list[str]:
     raw = _run(["git", "ls-tree", "-r", "--name-only", commit, "--", "plugins"])
     return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def _normalize_plugin_names(names: list[str]) -> list[str]:
+    filtered: list[str] = []
+    skipped: list[str] = []
+    for n in names:
+        if n and is_valid_plugin_dirname(n):
+            filtered.append(n)
+        else:
+            skipped.append(n)
+
+    if skipped:
+        print(
+            "Skipping invalid plugin directory names: "
+            + ", ".join(sorted(set(skipped)))
+            + " (expected lowercase letters, numbers, underscores only)"
+        )
+
+    return sorted(set(filtered))
 
 
 def get_plugin_names() -> list[str]:
@@ -49,7 +85,8 @@ def get_plugin_names() -> list[str]:
     """
     plugin_names_env = os.environ.get("PLUGIN_NAMES", "").strip()
     if plugin_names_env:
-        plugin_names = sorted(list(set(n.strip() for n in plugin_names_env.split(",") if n.strip())))
+        plugin_names = [n.strip() for n in plugin_names_env.split(",") if n.strip()]
+        plugin_names = _normalize_plugin_names(plugin_names)
     else:
         before = os.environ.get("BEFORE_SHA", "").strip()
         after = os.environ.get("AFTER_SHA", "").strip()
@@ -66,7 +103,7 @@ def get_plugin_names() -> list[str]:
             if len(parts) >= 2 and parts[0] == "plugins":
                 plugin_names_set.add(parts[1])
 
-        plugin_names = [n for n in sorted(plugin_names_set) if n and not n.startswith("_")]
+        plugin_names = _normalize_plugin_names(list(plugin_names_set))
 
     if not plugin_names:
         return []

--- a/scripts/update_plugin_discussions.py
+++ b/scripts/update_plugin_discussions.py
@@ -14,6 +14,7 @@ from plugin_resolution import (
     REPO_ROOT,
     PluginResolutionError,
     get_plugin_names,
+    is_valid_plugin_dirname,
 )
 
 DISCUSSIONS_CATEGORY_NAME = "Plugins"
@@ -50,6 +51,12 @@ def _fail(msg: str) -> NoReturn:
     raise UpdatePluginDiscussionsError(msg)
 
 
+
+def _run(cmd: list[str]) -> str:
+    out = subprocess.check_output(cmd, cwd=REPO_ROOT)
+    return out.decode("utf-8", errors="replace")
+
+
 def _is_transient_http_status(status: int) -> bool:
     return status in {408, 429, 500, 502, 503, 504}
 
@@ -81,6 +88,40 @@ def _plugin_exists(plugin_name: str) -> bool:
     plugin_yaml = PLUGINS_DIR / plugin_name / "plugin.yaml"
     return plugin_yaml.exists()
 
+
+def _get_removed_plugin_names() -> list[str]:
+    before = os.environ.get("BEFORE_SHA", "").strip()
+    after = os.environ.get("AFTER_SHA", "").strip()
+    if not before or not after:
+        return []
+
+    raw = _run(["git", "diff", "--name-status", f"{before}..{after}"])
+    removed: set[str] = set()
+
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("	")
+        if len(parts) < 2:
+            continue
+
+        status = parts[0]
+        old_path = ""
+        if status.startswith("D"):
+            old_path = parts[1]
+        elif status.startswith("R") and len(parts) >= 3:
+            old_path = parts[1]
+
+        if not old_path:
+            continue
+
+        path_parts = Path(old_path).parts
+        if len(path_parts) >= 2 and path_parts[0] == "plugins":
+            plugin_name = path_parts[1]
+            if is_valid_plugin_dirname(plugin_name):
+                removed.add(plugin_name)
+
+    return sorted(removed)
 
 def _read_plugin_yaml(plugin_name: str) -> dict[str, Any]:
     plugin_yaml = PLUGINS_DIR / plugin_name / "plugin.yaml"
@@ -337,6 +378,29 @@ def _find_existing_discussion(owner: str, repo: str, plugin_name: str, expected_
     return None
 
 
+def _close_discussion(discussion_id: str) -> None:
+    query = """
+    mutation($id: ID!) {
+      closeDiscussion(input: {discussionId: $id}) {
+        discussion {
+          id
+          url
+          closed
+        }
+      }
+    }
+    """
+
+    data = _graphql_request(query, {"id": discussion_id})
+    cd = data.get("closeDiscussion")
+    if not isinstance(cd, dict):
+        _fail("Unexpected GraphQL response: missing closeDiscussion")
+    disc = cd.get("discussion")
+    if not isinstance(disc, dict):
+        _fail("Unexpected GraphQL response: missing discussion")
+    if disc.get("closed") is not True:
+        _fail("Attempted to close discussion but it is still open")
+
 def _reopen_discussion(discussion_id: str) -> None:
     query = """
     mutation($id: ID!) {
@@ -435,8 +499,36 @@ def main() -> int:
 
     created = 0
     updated = 0
+    closed = 0
     skipped = 0
     failed: list[str] = []
+
+    removed_plugin_names = _get_removed_plugin_names()
+    for plugin_name in removed_plugin_names:
+        if _plugin_exists(plugin_name):
+            continue
+        try:
+            expected_title = _discussion_title(plugin_name)
+
+            def _find_removed() -> dict[str, Any] | None:
+                return _find_existing_discussion(owner, repo, plugin_name, expected_title)
+
+            existing = _with_retries(f"search removed discussion {plugin_name}", _find_removed)
+            if not existing:
+                continue
+
+            disc_id = existing.get("id")
+            is_closed = existing.get("closed") is True
+            if isinstance(disc_id, str) and disc_id and not is_closed:
+                _with_retries(f"close discussion {plugin_name}", lambda: _close_discussion(disc_id))
+                closed += 1
+                print(f"Closed: {plugin_name} -> {existing.get('url')}")
+        except UpdatePluginDiscussionsError as e:
+            failed.append(plugin_name)
+            print(f"ERROR: removed plugin={plugin_name}: {e}")
+        except Exception as e:
+            failed.append(plugin_name)
+            print(f"ERROR: removed plugin={plugin_name}: {e}")
 
     for plugin_name in plugin_names:
         try:
@@ -453,9 +545,9 @@ def main() -> int:
             existing = _with_retries(f"search discussion {plugin_name}", _find)
             if existing:
                 disc_id = existing.get("id")
-                closed = existing.get("closed")
+                is_existing_closed = existing.get("closed")
                 existing_url = existing.get("url") if isinstance(existing.get("url"), str) else ""
-                if isinstance(disc_id, str) and closed is True:
+                if isinstance(disc_id, str) and is_existing_closed is True:
                     _with_retries(f"reopen discussion {plugin_name}", lambda: _reopen_discussion(disc_id))
 
                 if isinstance(disc_id, str) and disc_id:
@@ -486,7 +578,7 @@ def main() -> int:
             print(f"ERROR: plugin={plugin_name}: {e}")
 
     print(
-        f"Done. created={created} updated={updated} skipped={skipped} "
+        f"Done. created={created} updated={updated} closed={closed} skipped={skipped} "
         f"failed={len(failed)} total={len(plugin_names)}"
     )
     if failed:

--- a/scripts/validate_pr.py
+++ b/scripts/validate_pr.py
@@ -1,37 +1,41 @@
 import os
 import re
 import subprocess
-import sys
 import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import NoReturn, cast
+from typing import Any, NoReturn, cast
 
 import yaml
 from PIL import Image
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-PLUGINS_DIR = REPO_ROOT / "plugins"
 
-ALLOWED_YAML_KEYS = {"title", "description", "github", "tags"}
+ALLOWED_YAML_KEYS = {"title", "description", "github", "tags", "screenshots"}
 REQUIRED_YAML_KEYS = {"title", "description", "github"}
 ALLOWED_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp"}
 MAX_IMAGE_BYTES = 20 * 1024
-MAX_SCREENSHOT_BYTES = 250 * 1024
+MAX_SCREENSHOT_BYTES = 2 * 1024 * 1024
+MAX_SCREENSHOTS = 5
+MAX_SCREENSHOT_URL_LENGTH = 200
 MAX_TAGS = 5
+MAX_TAG_LENGTH = 30
 THUMBNAIL_BASENAME = "thumbnail"
-SCREENSHOTS_DIRNAME = "screenshots"
-MAX_SCREENSHOTS = 3
-ALLOWED_SCREENSHOT_BASENAMES = {"1", "2", "3"}
 MAX_TITLE_LENGTH = 50
 MAX_DESCRIPTION_LENGTH = 500
+MAX_PLUGIN_YAML_CHARS = 2000
+PLUGIN_DIRNAME_PATTERN = re.compile(r"^[a-z0-9_]+$")
 
 
 class ValidationError(Exception):
     pass
+
+
+def _is_valid_plugin_dirname(plugin_name: str) -> bool:
+    return bool(PLUGIN_DIRNAME_PATTERN.fullmatch(plugin_name))
 
 
 def _run(cmd: list[str]) -> str:
@@ -56,23 +60,17 @@ def _git_show_bytes(commit: str, file_path: str) -> bytes:
 
 
 def _get_changed_files(base_sha: str, head_sha: str) -> list[tuple[str, str]]:
-    # Use name-status so we can detect deleted/renamed files.
     raw = _run(["git", "diff", "--name-status", f"{base_sha}..{head_sha}"])
     changes: list[tuple[str, str]] = []
     for line in raw.splitlines():
         if not line.strip():
             continue
         parts = line.split("\t")
-        status = parts[0]
-        # For renames/copies, the format is: R100\told\tnew
-        # For others: A|M|D\tpath
-        path = parts[-1]
-        changes.append((status, path))
+        changes.append((parts[0], parts[-1]))
     return changes
 
 
 def _get_affected_paths(base_sha: str, head_sha: str) -> list[str]:
-    """Return every path mentioned by the name-status diff, including old/new paths for renames/copies."""
     raw = _run(["git", "diff", "--name-status", f"{base_sha}..{head_sha}"])
     affected: list[str] = []
     for line in raw.splitlines():
@@ -81,7 +79,6 @@ def _get_affected_paths(base_sha: str, head_sha: str) -> list[str]:
         parts = line.split("\t")
         if len(parts) < 2:
             continue
-        # parts[0] is status. Remaining parts are paths (1 for A/M/D, 2 for R/C).
         for p in parts[1:]:
             p = p.strip()
             if p:
@@ -93,17 +90,67 @@ def _fail(msg: str) -> NoReturn:
     raise ValidationError(msg)
 
 
-def _validate_yaml_bytes(plugin_yaml_path: str, content: bytes) -> None:
-    loaded = None
+def _validate_remote_screenshot_url(plugin_yaml_path: str, screenshot_url: str) -> None:
+    if len(screenshot_url) > MAX_SCREENSHOT_URL_LENGTH:
+        _fail(
+            f"{plugin_yaml_path} screenshot URL exceeds {MAX_SCREENSHOT_URL_LENGTH} characters: {screenshot_url}"
+        )
+
+    parsed = urllib.parse.urlparse(screenshot_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        _fail(f"{plugin_yaml_path} screenshot URL must be a valid http(s) URL: {screenshot_url}")
+
+    ext = Path(parsed.path).suffix.lower()
+    if ext not in ALLOWED_IMAGE_EXTS:
+        _fail(
+            f"{plugin_yaml_path} screenshot URL must end with one of {sorted(ALLOWED_IMAGE_EXTS)}: {screenshot_url}"
+        )
+
+    req = urllib.request.Request(
+        screenshot_url,
+        headers={"User-Agent": "a0-plugins-validator"},
+    )
+
     try:
-        loaded = yaml.safe_load(content.decode("utf-8", errors="strict"))
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            total = 0
+            while True:
+                chunk = resp.read(64 * 1024)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > MAX_SCREENSHOT_BYTES:
+                    _fail(
+                        f"{plugin_yaml_path} screenshot exceeds max size {MAX_SCREENSHOT_BYTES} bytes: {screenshot_url}"
+                    )
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace") if hasattr(e, "read") else str(e)
+        _fail(f"Unable to fetch screenshot URL ({e.code}) {screenshot_url}: {body[:300]}")
+    except Exception as e:
+        _fail(f"Unable to fetch screenshot URL {screenshot_url}: {e}")
+
+
+def _validate_yaml_bytes(plugin_yaml_path: str, content: bytes) -> None:
+    try:
+        yaml_text = content.decode("utf-8", errors="strict")
+    except Exception as e:
+        _fail(f"Invalid UTF-8 in {plugin_yaml_path}: {e}")
+
+    if len(yaml_text) > MAX_PLUGIN_YAML_CHARS:
+        _fail(
+            f"{plugin_yaml_path} must be at most {MAX_PLUGIN_YAML_CHARS} characters"
+        )
+
+    loaded: Any = None
+    try:
+        loaded = yaml.safe_load(yaml_text)
     except Exception as e:
         _fail(f"Invalid YAML in {plugin_yaml_path}: {e}")
 
-    data = loaded
-
-    if not isinstance(data, dict):
+    if not isinstance(loaded, dict):
         _fail(f"{plugin_yaml_path} must contain a YAML mapping/object")
+
+    data = cast(dict[str, Any], loaded)
 
     keys = set(data.keys())
     extra = keys - ALLOWED_YAML_KEYS
@@ -115,9 +162,7 @@ def _validate_yaml_bytes(plugin_yaml_path: str, content: bytes) -> None:
             f"Allowed fields are: {sorted(ALLOWED_YAML_KEYS)}"
         )
     if missing:
-        _fail(
-            f"{plugin_yaml_path} is missing required fields: {sorted(missing)}"
-        )
+        _fail(f"{plugin_yaml_path} is missing required fields: {sorted(missing)}")
 
     for k in REQUIRED_YAML_KEYS:
         v = data.get(k)
@@ -126,82 +171,59 @@ def _validate_yaml_bytes(plugin_yaml_path: str, content: bytes) -> None:
 
     title = data.get("title")
     if isinstance(title, str) and len(title) > MAX_TITLE_LENGTH:
-        _fail(
-            f"{plugin_yaml_path} field 'title' must be at most {MAX_TITLE_LENGTH} characters"
-        )
+        _fail(f"{plugin_yaml_path} field 'title' must be at most {MAX_TITLE_LENGTH} characters")
 
     description = data.get("description")
     if isinstance(description, str) and len(description) > MAX_DESCRIPTION_LENGTH:
-        _fail(
-            f"{plugin_yaml_path} field 'description' must be at most {MAX_DESCRIPTION_LENGTH} characters"
-        )
+        _fail(f"{plugin_yaml_path} field 'description' must be at most {MAX_DESCRIPTION_LENGTH} characters")
 
     github = data.get("github")
     if isinstance(github, str) and not re.match(r"^https?://", github.strip()):
-        _fail(
-            f"{plugin_yaml_path} field 'github' must be a valid http(s) URL"
-        )
-
+        _fail(f"{plugin_yaml_path} field 'github' must be a valid http(s) URL")
     if isinstance(github, str):
         _validate_github_repo(github.strip())
 
     if "tags" in data:
         tags = data.get("tags")
-        if tags is None:
-            _fail(f"{plugin_yaml_path} field 'tags' must be a list of strings")
         if not isinstance(tags, list) or not all(isinstance(t, str) and t.strip() for t in tags):
-            _fail(f"{plugin_yaml_path} field 'tags' must be a list of strings")
+            _fail(f"{plugin_yaml_path} field 'tags' must be a list of non-empty strings")
         tags_list = cast(list[str], tags)
         if len(tags_list) > MAX_TAGS:
-            _fail(
-                f"{plugin_yaml_path} field 'tags' must contain at most {MAX_TAGS} entries"
-            )
+            _fail(f"{plugin_yaml_path} field 'tags' must contain at most {MAX_TAGS} entries")
+        for tag in tags_list:
+            if len(tag) > MAX_TAG_LENGTH:
+                _fail(f"{plugin_yaml_path} tag '{tag}' exceeds max length {MAX_TAG_LENGTH}")
+
+    if "screenshots" in data:
+        screenshots = data.get("screenshots")
+        if not isinstance(screenshots, list) or not all(isinstance(s, str) and s.strip() for s in screenshots):
+            _fail(f"{plugin_yaml_path} field 'screenshots' must be a list of non-empty URL strings")
+        screenshot_list = cast(list[str], screenshots)
+        if len(screenshot_list) > MAX_SCREENSHOTS:
+            _fail(f"{plugin_yaml_path} field 'screenshots' must contain at most {MAX_SCREENSHOTS} entries")
+        for screenshot_url in screenshot_list:
+            _validate_remote_screenshot_url(plugin_yaml_path, screenshot_url.strip())
 
 
 def _validate_thumbnail(image_path: Path) -> None:
     if image_path.suffix.lower() not in ALLOWED_IMAGE_EXTS:
-        _fail(
-            f"Thumbnail must be one of {sorted(ALLOWED_IMAGE_EXTS)}: {image_path.relative_to(REPO_ROOT)}"
-        )
+        _fail(f"Thumbnail must be one of {sorted(ALLOWED_IMAGE_EXTS)}: {image_path.name}")
 
     size = image_path.stat().st_size
     if size > MAX_IMAGE_BYTES:
-        _fail(
-            f"Thumbnail is too large ({size} bytes). Max is {MAX_IMAGE_BYTES} bytes: {image_path.relative_to(REPO_ROOT)}"
-        )
+        _fail(f"Thumbnail is too large ({size} bytes). Max is {MAX_IMAGE_BYTES} bytes")
 
     try:
         with Image.open(image_path) as im:
             w, h = im.size
     except Exception as e:
-        _fail(f"Thumbnail image could not be opened: {image_path.relative_to(REPO_ROOT)}: {e}")
+        _fail(f"Thumbnail image could not be opened: {e}")
 
     if w != h:
-        _fail(
-            f"Thumbnail must be square (width == height). Got {w}x{h}: {image_path.relative_to(REPO_ROOT)}"
-        )
+        _fail(f"Thumbnail must be square (width == height). Got {w}x{h}")
 
 
-def _validate_screenshot(image_path: Path) -> None:
-    if image_path.suffix.lower() not in ALLOWED_IMAGE_EXTS:
-        _fail(
-            f"Screenshot must be one of {sorted(ALLOWED_IMAGE_EXTS)}: {image_path.relative_to(REPO_ROOT)}"
-        )
-
-    size = image_path.stat().st_size
-    if size > MAX_SCREENSHOT_BYTES:
-        _fail(
-            f"Screenshot is too large ({size} bytes). Max is {MAX_SCREENSHOT_BYTES} bytes: {image_path.relative_to(REPO_ROOT)}"
-        )
-
-    try:
-        with Image.open(image_path) as _:
-            pass
-    except Exception as e:
-        _fail(f"Screenshot image could not be opened: {image_path.relative_to(REPO_ROOT)}: {e}")
-
-
-def _github_api_get_json(url: str) -> dict:
+def _github_api_get_json(url: str) -> dict[str, Any]:
     token = os.environ.get("GITHUB_TOKEN")
     headers = {
         "Accept": "application/vnd.github+json",
@@ -221,9 +243,13 @@ def _github_api_get_json(url: str) -> dict:
         _fail(f"GitHub API request failed for {url}: {e}")
 
     try:
-        return cast(dict, __import__("json").loads(payload))
+        parsed = __import__("json").loads(payload)
     except Exception as e:
         _fail(f"GitHub API returned invalid JSON for {url}: {e}")
+
+    if not isinstance(parsed, dict):
+        _fail(f"GitHub API returned non-object JSON for {url}")
+    return cast(dict[str, Any], parsed)
 
 
 def _parse_github_repo_url(repo_url: str) -> tuple[str, str]:
@@ -263,9 +289,6 @@ def main() -> int:
     if not base_sha or not head_sha:
         _fail("BASE_SHA and HEAD_SHA environment variables are required")
 
-    base_sha = cast(str, base_sha)
-    head_sha = cast(str, head_sha)
-
     changes = _get_changed_files(base_sha, head_sha)
     if not changes:
         _fail("No changed files detected")
@@ -274,7 +297,6 @@ def main() -> int:
     if not affected_paths:
         _fail("No changed files detected")
 
-    # Only allow modifications within exactly one plugin folder.
     plugin_roots: set[Path] = set()
     for p in affected_paths:
         parts = p.parts
@@ -286,17 +308,16 @@ def main() -> int:
         plugin_roots.add(Path(parts[0]) / parts[1])
 
     if len(plugin_roots) != 1:
-        _fail(
-            f"PR must submit exactly one plugin folder. Found: {sorted(pr.as_posix() for pr in plugin_roots)}"
-        )
+        _fail(f"PR must submit exactly one plugin folder. Found: {sorted(pr.as_posix() for pr in plugin_roots)}")
 
     plugin_root_rel = next(iter(plugin_roots))
     plugin_name = plugin_root_rel.parts[1]
 
     if plugin_name.startswith("_"):
-        _fail(
-            f"Plugin folder '{plugin_name}' starts with '_' which is reserved and not visible in Agent Zero"
-        )
+        _fail(f"Plugin folder '{plugin_name}' starts with '_' which is reserved and not visible in Agent Zero")
+
+    if not _is_valid_plugin_dirname(plugin_name):
+        _fail(f"Plugin folder '{plugin_name}' must use lowercase letters, numbers, and underscores only")
 
     plugin_root_path = plugin_root_rel.as_posix()
     plugin_files = _git_ls_tree_names(head_sha, plugin_root_path)
@@ -307,33 +328,16 @@ def main() -> int:
     if plugin_yaml_path not in plugin_files:
         _fail(f"Missing required file in PR head: {plugin_yaml_path}")
 
-    # Validate no extra files and optional thumbnail/screenshots naming.
     thumbnails: list[str] = []
-    screenshots: list[str] = []
     for f in plugin_files:
         path_obj = Path(f)
-        name = path_obj.name
-        if name == "plugin.yaml":
-            continue
-
-        if len(path_obj.parts) == 3 and path_obj.parts[1] == SCREENSHOTS_DIRNAME:
-            suffix = path_obj.suffix.lower()
-            if suffix not in ALLOWED_IMAGE_EXTS:
-                _fail(
-                    f"Screenshot must use one of {sorted(ALLOWED_IMAGE_EXTS)}: {f}"
-                )
-            if path_obj.stem not in ALLOWED_SCREENSHOT_BASENAMES:
-                _fail(
-                    f"Screenshot filename must be numbered 1, 2, or 3 (example: screenshots/1.png). Found: {f}"
-                )
-            screenshots.append(f)
+        if path_obj.name == "plugin.yaml":
             continue
 
         if len(path_obj.parts) == 2:
             suffix = path_obj.suffix.lower()
             if suffix in ALLOWED_IMAGE_EXTS:
-                stem = path_obj.stem.lower()
-                if stem != THUMBNAIL_BASENAME:
+                if path_obj.stem.lower() != THUMBNAIL_BASENAME:
                     _fail(
                         f"Thumbnail must be named '{THUMBNAIL_BASENAME}<ext>' (e.g. thumbnail.png). Found: {f}"
                     )
@@ -341,19 +345,13 @@ def main() -> int:
                 continue
 
         _fail(
-            "Unsupported file in plugin folder: "
-            f"{f}. Only plugin.yaml, an optional thumbnail image, and optional screenshots/1|2|3.<ext> files are allowed."
+            f"Unsupported file in plugin folder: {f}. "
+            "Only plugin.yaml and an optional thumbnail image are allowed. "
+            "Screenshots must be provided as external URLs in plugin.yaml."
         )
 
     if len(thumbnails) > 1:
         _fail("At most one thumbnail image is allowed. Found: " + ", ".join(thumbnails))
-
-    if len(screenshots) > MAX_SCREENSHOTS:
-        _fail(f"At most {MAX_SCREENSHOTS} screenshots are allowed. Found: " + ", ".join(screenshots))
-
-    screenshot_numbers = {Path(p).stem for p in screenshots}
-    if len(screenshot_numbers) != len(screenshots):
-        _fail("Duplicate screenshot numbers are not allowed. Use each of 1, 2, 3 at most once.")
 
     plugin_yaml_bytes = _git_show_bytes(head_sha, plugin_yaml_path)
     _validate_yaml_bytes(plugin_yaml_path, plugin_yaml_bytes)
@@ -367,25 +365,8 @@ def main() -> int:
         try:
             _validate_thumbnail(tmp_path)
         finally:
-            try:
-                tmp_path.unlink(missing_ok=True)
-            except Exception:
-                pass
+            tmp_path.unlink(missing_ok=True)
 
-    for screenshot_path in screenshots:
-        screenshot_bytes = _git_show_bytes(head_sha, screenshot_path)
-        with tempfile.NamedTemporaryFile(suffix=Path(screenshot_path).suffix, delete=False) as tmp:
-            tmp.write(screenshot_bytes)
-            tmp_path = Path(tmp.name)
-        try:
-            _validate_screenshot(tmp_path)
-        finally:
-            try:
-                tmp_path.unlink(missing_ok=True)
-            except Exception:
-                pass
-
-    # Ensure the PR didn't delete required files.
     deleted = [p for status, p in changes if status.startswith("D")]
     if deleted:
         _fail(f"PR must not delete files. Deleted: {deleted}")


### PR DESCRIPTION
### Motivation
- Allow plugins to reference screenshots by external URLs rather than committing image files to the index repo. 
- Enforce a stable plugin folder name pattern and robustly ignore invalid names when scanning or pruning the index. 
- Harden CI scripts to correctly parse git name-status diffs and close discussions for removed plugins.

### Description
- README: document new `screenshots` field in `plugin.yaml`, update folder/name guidance to require lowercase letters, numbers, and underscores, and describe URL-based screenshot rules. 
- `scripts/validate_pr.py`: accept `screenshots` in `plugin.yaml`, validate each screenshot URL (http(s), allowed extensions, length, reachable and <= 2 MB), raise max screenshot size and count limits, add max YAML file chars, enforce plugin directory name regex, remove local `screenshots/` file support, and tighten thumbnail/error messages. 
- `scripts/plugin_resolution.py`: add `is_valid_plugin_dirname`, normalize plugin name lists, and parse `git diff --name-status` outputs to collect paths robustly. 
- `scripts/generate_index.py`: include `screenshots` from `plugin.yaml` in generated `index.json` entries and prune index entries that do not match the valid plugin-name pattern. 
- `scripts/update_plugin_discussions.py`: detect removed plugins via git diff name-status, add logic to close discussions for deleted plugins, add helper `_close_discussion`, and make minor robustness fixes (git run helper and printed warnings for skipped names).

### Testing
- Performed local smoke runs of the validator with sample plugin manifests and thumbnails by executing `python scripts/validate_pr.py` against test `BASE_SHA`/`HEAD_SHA`, and the validator accepted valid manifests and rejected invalid cases (success). 
- Ran `python scripts/generate_index.py` locally to regenerate `index.json` from a test plugins set and confirmed entries include `screenshots` when present (success). 
- Executed `python scripts/update_plugin_discussions.py` in a controlled environment simulating git diffs to exercise the removed-plugin close flow; the script completed without exceptions in the smoke run (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaef8480a48332a19ba1ce368dd490)