### PR TITLE
Add YouTube Transcriber plugin

### DIFF
--- a/plugins/youtube_transcribe/plugin.yaml
+++ b/plugins/youtube_transcribe/plugin.yaml
@@ -1,0 +1,8 @@
+title: YouTube Transcriber
+description: Transcribe YouTube videos and playlists with visual context extraction, AI-powered summaries, and detailed timestamped notes.
+github: https://github.com/spinnakergit/a0-youtube-transcribe
+tags:
+  - video
+  - audio
+  - research
+  - automation


### PR DESCRIPTION
## Summary
- Adds the YouTube Transcriber plugin to the registry
- Transcribes YouTube videos/playlists with visual context extraction, AI-powered summaries, and detailed timestamped notes
- Source: https://github.com/spinnakergit/a0-youtube-transcribe

## Files Changed
- `plugins/youtube_transcribe/plugin.yaml` — Registry entry
