### PR TITLE
feat: add Honcho conversational memory plugin

### DIFF
--- a/plugins/honcho/plugin.yaml
+++ b/plugins/honcho/plugin.yaml
@@ -1,0 +1,7 @@
+title: Honcho Conversational Memory
+description: Persistent conversational memory via Honcho (by Plastic Labs). Automatically syncs all chat messages, retrieves summarised user context across sessions, and injects it into the agent system prompt. Requires a free Honcho API key.
+github: https://github.com/alogotron/a0-plugin-honcho
+tags:
+  - memory
+  - agents
+  - api


### PR DESCRIPTION
## Add Honcho Conversational Memory Plugin

### Plugin
**Honcho Conversational Memory** - Persistent conversational memory via [Honcho](https://honcho.dev) (by Plastic Labs).

### What it does
- Automatically syncs all user/assistant messages to Honcho Cloud
- Retrieves summarised user context across sessions
- Injects persistent context into the agent's system prompt
- Graceful degradation if Honcho is unavailable
- Secure by default (API key from secrets manager, never logged)

### Links
- **Plugin repo**: https://github.com/alogotron/a0-plugin-honcho
- **Honcho**: https://honcho.dev (by [Plastic Labs](https://plasticlabs.ai))
- **Reviewed by Plastic Labs**: https://github.com/plastic-labs/honcho/issues/411

### Notes
- Apache 2.0 licensed
- Uses `honcho-ai` SDK (>=2.0.0,<3.0.0)
- Includes privacy/data-flow disclosure
- Plastic Labs team has reviewed the plugin and is creating a community integration page on their docs
