### PR TITLE
Add agui_provider plugin

### DIFF
--- a/plugins/agui_provider/plugin.yaml
+++ b/plugins/agui_provider/plugin.yaml
@@ -1,0 +1,7 @@
+title: AG-UI Provider
+description: Expose Agent Zero as an AG-UI compatible server. Any CopilotKit or AG-UI frontend connects via streaming SSE with built-in auth and rate limiting.
+github: https://github.com/protolabs42/agui-provider
+tags:
+  - api
+  - agents
+  - web


### PR DESCRIPTION
## Summary
- Adds **AG-UI Provider** plugin to the marketplace index
- Exposes Agent Zero as an AG-UI compatible SSE server
- Any CopilotKit or AG-UI frontend can connect with built-in auth and rate limiting
- Repo: https://github.com/protolabs42/agui-provider