### PR TITLE
Add channels_provider plugin

### DIFF
--- a/plugins/channels_provider/plugin.yaml
+++ b/plugins/channels_provider/plugin.yaml
@@ -1,0 +1,7 @@
+title: Channels
+description: Unified messaging adapter for Discord, Telegram, and WhatsApp. Routes platform messages to agents and responses back to platforms.
+github: https://github.com/protolabs42/channels-provider
+tags:
+  - discord
+  - telegram
+  - integration


### PR DESCRIPTION
## Summary
- Adds **Channels** plugin to the marketplace index
- Unified messaging adapter for Discord, Telegram, and WhatsApp
- Routes platform messages to agents and responses back to platforms
- Repo: https://github.com/protolabs42/channels-provider