### PR TITLE
Add Signal Integration plugin

### DIFF
--- a/plugins/signal/index.yaml
+++ b/plugins/signal/index.yaml
@@ -1,0 +1,8 @@
+title: Signal Integration
+description: Secure messaging via Signal with E2E encryption. Send and receive messages, manage groups, and use Signal as a real-time chat bridge to Agent Zero.
+github: https://github.com/spinnakergit/a0-signal
+tags:
+  - security
+  - communication
+  - integration
+  - automation


### PR DESCRIPTION
## Summary

Adds the **Signal Integration** plugin to the Agent Zero plugin index.

- **Plugin repo:** https://github.com/spinnakergit/a0-signal
- **`name` in plugin.yaml:** `signal` (matches index folder `plugins/signal/`)
- **Version:** 1.0.0

### Features

- End-to-end encrypted messaging via Signal Protocol (X3DH + Double Ratchet)
- Dual-mode architecture: integrated (signal-cli native binary) or external (bbernhard/signal-cli-rest-api Docker container)
- Persistent chat bridge with restricted/elevated security modes
- 5 tools: signal_send, signal_read, signal_chat, signal_groups, signal_contacts
- Input sanitization, rate limiting, contact allowlists, HMAC-based auth
- 36/36 human validation tests passed (both integrated and external modes)

### Validation

- `index.yaml` follows the required format (title, description, github, tags)
- Folder name `signal` matches `name: signal` in remote `plugin.yaml`
- No thumbnail (will add later)
- Tags: security, communication, integration, automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)