### PR TITLE
Add twitterapiio plugin

### DIFF
--- a/plugins/twitterapiio/index.yaml
+++ b/plugins/twitterapiio/index.yaml
@@ -1,0 +1,6 @@
+title: TwitterAPI.io
+description: Twitter data retrieval via TwitterAPI.io — search tweets, user profiles, followers, lists, communities, trends, and real-time streams.
+github: https://github.com/protolabs42/twitterapiio
+tags:
+  - api
+  - integration


### PR DESCRIPTION
## Summary
- Adds **TwitterAPI.io** plugin to the marketplace index
- Skill-based plugin providing full TwitterAPI.io REST API documentation
- Agent reads API key from plugin config and uses it in HTTP calls
- Covers tweets, users, followers, lists, communities, trends, and real-time streams
- Repo: https://github.com/protolabs42/twitterapiio