### PR TITLE
Support suspended/blocked plugin markers in index and discussions

### DIFF
--- a/scripts/find_orphan_plugin_names.py
+++ b/scripts/find_orphan_plugin_names.py
@@ -12,6 +12,7 @@ from plugin_resolution import INDEX_YAML_NAME, PLUGINS_DIR, REPO_ROOT, is_reserv
 INDEX_JSON_PATH = REPO_ROOT / "index.json"
 PLUGIN_MARKER_PREFIX = "<!-- a0-plugins-plugin:"
 PLUGIN_MARKER_RE = re.compile(r"<!-- a0-plugins-plugin:([^>]+?) -->")
+BLOCKED_MD_NAME = "blocked.md"
 
 
 class FindOrphanPluginNamesError(Exception):
@@ -109,7 +110,8 @@ def _index_plugin_names_and_discussions() -> tuple[set[str], set[str]]:
 def _plugin_exists(plugin_name: str) -> bool:
     if is_reserved_plugin_dirname(plugin_name):
         return False
-    return (PLUGINS_DIR / plugin_name / INDEX_YAML_NAME).exists()
+    plugin_dir = PLUGINS_DIR / plugin_name
+    return (plugin_dir / INDEX_YAML_NAME).exists() and not (plugin_dir / BLOCKED_MD_NAME).exists()
 
 
 def _discussion_marker_name(body: str) -> str | None:

--- a/scripts/sync_plugin_state.py
+++ b/scripts/sync_plugin_state.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 import time
 import urllib.error
 import urllib.request
@@ -17,6 +18,8 @@ DISCUSSIONS_CATEGORY_NAME = "Plugins"
 DISCUSSION_MARKER = "<!-- a0-plugins-discussion -->"
 PLUGIN_MARKER_PREFIX = "<!-- a0-plugins-plugin:"
 DISCUSSION_TEMPLATE_PATH = REPO_ROOT / "scripts" / "plugin_discussion_template.md"
+SUSPENDED_MD_NAME = "suspended.md"
+BLOCKED_MD_NAME = "blocked.md"
 
 
 class SyncPluginStateError(Exception):
@@ -150,7 +153,21 @@ def _get_owner_repo() -> tuple[str, str]:
 def _plugin_exists(plugin_name: str) -> bool:
     if is_reserved_plugin_dirname(plugin_name):
         return False
-    return (PLUGINS_DIR / plugin_name / INDEX_YAML_NAME).exists()
+    plugin_dir = PLUGINS_DIR / plugin_name
+    return (plugin_dir / INDEX_YAML_NAME).exists() and not (plugin_dir / BLOCKED_MD_NAME).exists()
+
+
+def _plugin_blocked(plugin_name: str) -> bool:
+    plugin_dir = PLUGINS_DIR / plugin_name
+    return plugin_dir.exists() and (plugin_dir / BLOCKED_MD_NAME).exists()
+
+
+def _plugin_suspended_markdown(plugin_name: str) -> str | None:
+    plugin_dir = PLUGINS_DIR / plugin_name
+    suspended_md = plugin_dir / SUSPENDED_MD_NAME
+    if not suspended_md.exists():
+        return None
+    return suspended_md.read_text(encoding="utf-8").strip() or None
 
 
 def _read_plugin_yaml(plugin_name: str) -> dict[str, Any]:
@@ -267,7 +284,7 @@ def _index_plugin_entry(plugin_name: str, meta: dict[str, Any], discussion_url: 
     screenshots_val = meta.get("screenshots")
     screenshots = [s.strip() for s in screenshots_val if isinstance(s, str) and s.strip()] if isinstance(screenshots_val, list) else []
     thumb_rel = _thumbnail_rel_path(plugin_name)
-    return {
+    entry = {
         "title": title,
         "description": description,
         "github": gh,
@@ -277,6 +294,46 @@ def _index_plugin_entry(plugin_name: str, meta: dict[str, Any], discussion_url: 
         "screenshots": screenshots,
         "discussion": discussion_url,
     }
+    suspended = _plugin_suspended_markdown(plugin_name)
+    if suspended:
+        entry["suspended"] = suspended
+    return entry
+
+
+def _commit_has_plugin_file(commit: str, plugin_name: str, filename: str) -> bool:
+    if not commit or set(commit) == {"0"}:
+        return False
+    rel = f"plugins/{plugin_name}/{filename}"
+    result = subprocess.run(
+        ["git", "cat-file", "-e", f"{commit}:{rel}"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _suspension_comment_markdown(plugin_name: str) -> str | None:
+    before = os.environ.get("BEFORE_SHA", "").strip()
+    after = os.environ.get("AFTER_SHA", "").strip() or "HEAD"
+    suspended_before = _commit_has_plugin_file(before, plugin_name, SUSPENDED_MD_NAME)
+    blocked_before = _commit_has_plugin_file(before, plugin_name, BLOCKED_MD_NAME)
+    suspended_after = _commit_has_plugin_file(after, plugin_name, SUSPENDED_MD_NAME)
+    blocked_after = _commit_has_plugin_file(after, plugin_name, BLOCKED_MD_NAME)
+    was_suspended = suspended_before or blocked_before
+    is_suspended = suspended_after or blocked_after
+    if was_suspended == is_suspended:
+        return None
+    if is_suspended:
+        markdown = _plugin_suspended_markdown(plugin_name)
+        if markdown is None and _plugin_blocked(plugin_name):
+            blocked_md = PLUGINS_DIR / plugin_name / BLOCKED_MD_NAME
+            markdown = blocked_md.read_text(encoding="utf-8").strip() or None
+        message = "### This plugin has been suspended"
+        if markdown:
+            return f"{message}\n\n{markdown}"
+        return f"{message}\n\nTemporarily suspended by repository maintainers."
+    return "### Plugin has been unsuspended"
 
 
 def _upsert_index_plugin(index: dict[str, Any], plugin_name: str, entry: dict[str, Any]) -> None:
@@ -486,6 +543,23 @@ def _close_discussion(discussion_id: str) -> dict[str, Any]:
     return cast(dict[str, Any], payload.get("discussion"))
 
 
+def _add_discussion_comment(discussion_id: str, body: str) -> None:
+    query = """
+    mutation($discussionId: ID!, $body: String!) {
+      addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+        comment {
+          id
+        }
+      }
+    }
+    """
+    data = _graphql_request(query, {"discussionId": discussion_id, "body": body})
+    payload = data.get("addDiscussionComment")
+    comment = payload.get("comment") if isinstance(payload, dict) else None
+    if not isinstance(comment, dict) or not isinstance(comment.get("id"), str):
+        _fail("Unexpected GraphQL response: missing discussion comment")
+
+
 def _sync_existing_plugin(
     owner: str,
     repo: str,
@@ -500,6 +574,7 @@ def _sync_existing_plugin(
         f"search discussion {plugin_name}",
         lambda: _find_existing_discussion(owner, repo, plugin_name),
     )
+    suspension_comment = _suspension_comment_markdown(plugin_name)
     if existing and isinstance(existing.get("id"), str):
         discussion_id = cast(str, existing.get("id"))
         if existing.get("closed") is True:
@@ -512,6 +587,11 @@ def _sync_existing_plugin(
             f"update discussion {plugin_name}",
             lambda: _update_discussion(discussion_id, title, body),
         )
+        if suspension_comment:
+            _with_retries(
+                f"comment discussion {plugin_name}",
+                lambda: _add_discussion_comment(discussion_id, suspension_comment),
+            )
         url = discussion.get("url") if isinstance(discussion.get("url"), str) else ""
         if not url:
             _fail(f"Updated discussion missing url for '{plugin_name}'")
@@ -520,6 +600,11 @@ def _sync_existing_plugin(
         f"create discussion {plugin_name}",
         lambda: _create_discussion(repo_id, category_id, title, body),
     )
+    if suspension_comment and isinstance(discussion.get("id"), str):
+        _with_retries(
+            f"comment discussion {plugin_name}",
+            lambda: _add_discussion_comment(cast(str, discussion.get("id")), suspension_comment),
+        )
     url = discussion.get("url") if isinstance(discussion.get("url"), str) else ""
     if not url:
         _fail(f"Created discussion missing url for '{plugin_name}'")
@@ -567,6 +652,20 @@ def main() -> int:
 
     for plugin_name in plugin_names:
         try:
+            if _plugin_blocked(plugin_name):
+                action, discussion_url = _sync_existing_plugin(owner, repo, repo_id, category_id, plugin_name)
+                if action == "created":
+                    created += 1
+                else:
+                    updated += 1
+                if _remove_index_plugin(index, plugin_name):
+                    removed += 1
+                    print(f"Removed from index: {plugin_name}")
+                else:
+                    print(f"Missing from index: {plugin_name}")
+                print(f"{action.capitalize()} blocked plugin discussion: {plugin_name} -> {discussion_url}")
+                continue
+
             if _plugin_exists(plugin_name):
                 action, discussion_url = _sync_existing_plugin(owner, repo, repo_id, category_id, plugin_name)
                 meta = _read_plugin_yaml(plugin_name)


### PR DESCRIPTION
### Motivation
- Add support for repository-side suspension/blocking markers so the index/discussion state reflects `plugins/<name>/suspended.md` and `plugins/<name>/blocked.md` consistently.
- `suspended.md` should be stored in `index.json` as a `suspended` field containing the markdown, and `blocked.md` should exclude the plugin from the index (same effect as deleting the folder).
- Ensure the change works from both sides (sync and orphan detection) and notify the discussion thread when suspension state flips in a commit.

### Description
- Updated `scripts/sync_plugin_state.py` to add `SUSPENDED_MD_NAME` and `BLOCKED_MD_NAME` constants and read `suspended.md` content via `_plugin_suspended_markdown` and detect blocked state via `_plugin_blocked`.
- Changed ` _plugin_exists` to treat a plugin with `blocked.md` as non-existent for indexing, and added `suspended` content to the index entry in `_index_plugin_entry` when present.
- Added commit-aware detection helpers `_commit_has_plugin_file` and `_suspension_comment_markdown` and a GraphQL helper `_add_discussion_comment` to post comments to the plugin discussion when suspension state changes between `BEFORE_SHA`/`AFTER_SHA` (messages: `### This plugin has been suspended` + content or `### Plugin has been unsuspended`).
- Adjusted the main sync loop to still sync/update discussion for blocked plugins but remove/skip them from `index.json`, and updated `scripts/find_orphan_plugin_names.py` to consider `blocked.md` as excluding a plugin from existence.

### Testing
- Compiled the updated modules with `python -m py_compile scripts/sync_plugin_state.py scripts/find_orphan_plugin_names.py`, which completed successfully.
- Verified repository changes via `git show --stat` and `git status`, and recorded the commit created for this work as part of the change process.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1316215908332895ed85a4fd0bdf0)