### PR TITLE
Fix validate workflow: download index.json before validation

### DIFF
--- a/.github/workflows/validate-plugin-pr.yml
+++ b/.github/workflows/validate-plugin-pr.yml
@@ -67,6 +67,15 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pyyaml pillow
 
+      - name: Download current index.json (best effort)
+        if: ${{ steps.pr_meta.outputs.should_run == 'true' }}
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ steps.bot-app-token.outputs.token }}
+          INDEX_RELEASE_TAG: generated-index
+        run: |
+          python scripts/download_index_release.py
+
       - name: Validate plugin submission
         id: validate_submission
         if: ${{ steps.pr_meta.outputs.should_run == 'true' }}


### PR DESCRIPTION
## Summary

Adds a "Download current index.json" step to `validate-plugin-pr.yml`, mirroring the step already in `generate-plugin-state.yml`.

## Problem

`index.json` is stored as a GitHub Release asset (tag `generated-index`), not in the git tree. Deletion PRs require the plugin to be present in `index.json` (via `_indexed_plugin()`), but the validate workflow never downloaded it — so `_load_index_plugins()` always returned `{}` and all deletion PRs failed with:

```
ERROR: Cannot delete plugin '...' because it is not present in index.json
```

## Fix

Add `continue-on-error: true` download step immediately before the validate step. If the release doesn't exist the step is skipped gracefully.

## Related

Unblocks #63 (plugin removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)