### PR TITLE
Add Slack Integration plugin

### DIFF
--- a/plugins/slack/index.yaml
+++ b/plugins/slack/index.yaml
@@ -1,0 +1,12 @@
+title: Slack Integration
+description: >
+  Read, send, and manage messages in Slack workspaces.
+  Includes a real-time Socket Mode chat bridge with dual-mode security
+  (restricted and elevated), DM-only authentication, prompt injection defense,
+  workspace search, channel management, and a WebUI dashboard.
+github: https://github.com/spinnakergit/a0-slack
+tags:
+  - messaging
+  - slack
+  - chat
+  - productivity


### PR DESCRIPTION
## Summary
- Adds the **Slack Integration** plugin (`slack`) to the plugin index
- 7 tools: read, send, members, search, summarize, manage, chat bridge
- Socket Mode chat bridge with dual-mode security (restricted/elevated)
- DM-only authentication, prompt injection defense, WebUI dashboard
- Repository: https://github.com/spinnakergit/a0-slack

## Verification
- Automated regression: 58/58 PASS
- Human verification: 70/70 PASS (12 code fixes applied)
- Security assessment: 0 Critical, 0 High (Stage 3a white-box)
- Pre-publish sanitization: PASS (no secrets, PII, or real IDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)