### PR TITLE
Add Google Suite plugin

### DIFF
--- a/plugins/google/index.yaml
+++ b/plugins/google/index.yaml
@@ -1,0 +1,12 @@
+title: Google Suite
+description: >
+  Unified Google integration with 21 tools across Gmail, Calendar, Drive,
+  Contacts, and Tasks. Shared OAuth2 authentication, per-service toggles,
+  email sanitization, path traversal protection, and a tabbed WebUI dashboard.
+github: https://github.com/spinnakergit/a0-google
+tags:
+  - google
+  - gmail
+  - calendar
+  - drive
+  - productivity


### PR DESCRIPTION
## Summary
- Adds the **Google Suite** plugin (`google/`) to the plugin index
- 21 tools across 5 Google services: Gmail (6), Calendar (5), Drive (5), Contacts (3), Tasks (2)
- Shared OAuth2 authentication with dynamic scope assembly and per-service toggles
- Tabbed WebUI dashboard, email sanitization, path traversal protection, recipient allow-list

## Verification
- 47/47 automated regression tests passed
- 59/59 human verification tests passed
- Security assessment completed (0 Critical, 0 High vulnerabilities)
- Pre-publish sanitization sweep passed

## Repository
https://github.com/spinnakergit/a0-google

🤖 Generated with [Claude Code](https://claude.com/claude-code)