### PR TITLE
feat: add knowledge_upload plugin

### DIFF
--- a/plugins/knowledge_upload/index.yaml
+++ b/plugins/knowledge_upload/index.yaml
@@ -1,0 +1,7 @@
+title: Knowledge Upload
+description: Adds a Knowledge button to the chat input area for quick access to the file browser, enabling easy management of knowledge files with automatic reindexing. Project aware.
+github: https://github.com/mbradaschia/a0-knowledge-upload
+tags:
+  - memory
+  - files
+  - rag


### PR DESCRIPTION
## Plugin: Knowledge Upload

Adds a Knowledge button to the chat input area (next to Pause Agent and Nudge) for quick access to the file browser, enabling easy management of knowledge files with automatic reindexing. Project aware: opens the project knowledge folder when a project is active, or the global custom knowledge directory otherwise.

Agent Zero v1.1 has full backend support for knowledge file management (project-aware path resolution, file browser integration, and automatic reindexing via `loadKnowledge()`), but the UI button to trigger it was never wired up. This plugin fills that gap.

- **GitHub**: https://github.com/mbradaschia/a0-knowledge-upload
- **Tags**: memory, files, rag
- **License**: MIT