### PR TITLE
feat: add stop_process plugin

### DIFF
--- a/plugins/stop_process/index.yaml
+++ b/plugins/stop_process/index.yaml
@@ -1,0 +1,7 @@
+title: Stop Process
+description: Adds a Stop button to the chat input actions bar to cancel/abort the currently running agent process and return to idle. Unlike Pause (which suspends) or Nudge (which restarts), Stop fully terminates the process.
+github: https://github.com/mbradaschia/a0-stop-process
+tags:
+  - ui
+  - productivity
+  - chat


### PR DESCRIPTION
Adds the **Stop Process** plugin to the Plugin Index.

## What it does
Adds a **Stop** button to the chat input actions bar (next to Pause Agent and Nudge) that **cancels/aborts** the currently running agent process and returns the agent to idle state.

## Why it is needed
Agent Zero currently has **Pause** (soft suspend, resumes on Resume) and **Nudge** (kills + restarts with a nudge message), but no way to simply **cancel a wrong command and go idle**. This plugin fills that gap.

## Features
- Always visible button: gray/disabled when idle, red when a process is running
- Calls `context.kill_process()` to fully terminate the running DeferredTask
- Shows "⛔ Process stopped by user." warning in the chat log
- Immediately resets the UI input box to idle (no polling delay)
- Toast notification on success/failure

## Plugin repo
https://github.com/mbradaschia/a0-stop-process