### PR TITLE
fix(phantom_bridge): update repository URL to new location

### DIFF
--- a/plugins/phantom_bridge/index.yaml
+++ b/plugins/phantom_bridge/index.yaml
@@ -3,11 +3,11 @@ description: >
   Log into any service once — A0 uses it forever. Opens a remote browser
   viewer (noVNC) so you can authenticate from your own browser. A0 inherits
   those sessions, learns site patterns, and can replay recorded workflows.
-github: https://github.com/Nunezchef/phantom-bridge
+github: https://github.com/notabotchef/phantom-bridge
 tags:
   - browser
   - authentication
   - automation
   - tools
 screenshots:
-  - https://raw.githubusercontent.com/Nunezchef/phantom-bridge/main/docs/banner.png
+  - https://raw.githubusercontent.com/notabotchef/phantom-bridge/main/docs/banner.png


### PR DESCRIPTION
## Summary

Same `phantom_bridge` plugin already listed in the index — just pointing `index.yaml` at its new home.

- `github:` updated from `Nunezchef/phantom-bridge` → `notabotchef/phantom-bridge`
- Screenshot URL updated to match

The original repository is no longer available at the old address; this PR restores a working link so the plugin remains installable from the index.

## Test plan
- [x] `plugins/phantom_bridge/index.yaml` resolves to a live repo
- [x] Screenshot URL returns 200