### PR TITLE
feat: add Telegram Mini App plugin

### DIFF
--- a/plugins/telegram_miniapp/index.yaml
+++ b/plugins/telegram_miniapp/index.yaml
@@ -14,4 +14,4 @@ screenshots:
   - https://raw.githubusercontent.com/notabotchef/a0-TelegramMiniApp/main/Screenshots/CleanShot%202026-04-13%20at%2002.56.35%402x.png
   - https://raw.githubusercontent.com/notabotchef/a0-TelegramMiniApp/main/Screenshots/CleanShot%202026-04-13%20at%2003.28.40%402x.png
   - https://raw.githubusercontent.com/notabotchef/a0-TelegramMiniApp/main/Screenshots/CleanShot%202026-04-13%20at%2003.29.24%402x.png
-  - https://raw.githubusercontent.com/notabotchef/a0-TelegramMiniApp/main/Screenshots/thumbnail.png
+  - https://raw.githubusercontent.com/notabotchef/a0-TelegramMiniApp/main/Screenshots/logo.png

--- a/plugins/telegram_miniapp/index.yaml
+++ b/plugins/telegram_miniapp/index.yaml
@@ -1,0 +1,17 @@
+title: Telegram Mini App
+description: >
+  Auth + shell bridge that exposes Agent Zero as a Telegram Mini App with
+  terminal-style streaming chat, Ed25519 initData auth, and a local gateway
+  running over a Cloudflare tunnel.
+github: https://github.com/notabotchef/a0-TelegramMiniApp
+tags:
+  - telegram
+  - web
+  - api
+  - security
+  - integration
+screenshots:
+  - https://raw.githubusercontent.com/notabotchef/a0-TelegramMiniApp/main/Screenshots/CleanShot%202026-04-13%20at%2002.56.35%402x.png
+  - https://raw.githubusercontent.com/notabotchef/a0-TelegramMiniApp/main/Screenshots/CleanShot%202026-04-13%20at%2003.28.40%402x.png
+  - https://raw.githubusercontent.com/notabotchef/a0-TelegramMiniApp/main/Screenshots/CleanShot%202026-04-13%20at%2003.29.24%402x.png
+  - https://raw.githubusercontent.com/notabotchef/a0-TelegramMiniApp/main/Screenshots/thumbnail.png


### PR DESCRIPTION
## Summary
- Adds `telegram_miniapp` plugin entry pointing to https://github.com/notabotchef/a0-TelegramMiniApp
- Terminal-style Telegram Mini App for Agent Zero
- Features: streaming chat, live activity feed (Socket.IO), LLM switcher, shell access, cron manager
- Drop-in plugin: copy `_miniapp/` to `usr/plugins/` in Agent Zero

## Screenshots
See plugin repo README for screenshots and setup guide.