### PR TITLE
Add plugin: karpathy_guidelines

### DIFF
--- a/plugins/karpathy_guidelines/index.yaml
+++ b/plugins/karpathy_guidelines/index.yaml
@@ -1,0 +1,3 @@
+title: Karpathy Guidelines
+description: Behavioral guidelines to reduce common LLM coding mistakes, enforces simplicity, surgical changes, surface assumptions, and goal-driven execution with verifiable success criteria.
+github: https://github.com/sendralt/karpathy-guidelines


### PR DESCRIPTION
## Add plugin: karpathy_guidelines

Adding Karpathy Guidelines to the community plugin index.

## Plugin details
- **Name**: karpathy_guidelines
- **Title**: Karpathy Guidelines
- **Repo**: https://github.com/sendralt/karpathy-guidelines

## Checklist
- [x] Exactly one new plugin folder added
- [x] Folder name matches plugin.yaml name field (karpathy_guidelines)
- [x] index.yaml contains all required fields
- [x] GitHub repo exists and contains plugin.yaml at root
- [x] No extra files in plugin folder