### PR TITLE
Add AZPowers Skills plugin

### DIFF
--- a/plugins/azpowers_skills/index.yaml
+++ b/plugins/azpowers_skills/index.yaml
@@ -1,0 +1,7 @@
+title: AZPowers Skills
+description: Agent Zero capability layer for memory, payments, RSI, wallet, swarm, ITP compression, and native crypto primitives via ClawPowers-Skills.
+github: https://github.com/up2itnow0822/AZPowers-Skills
+tags:
+  - tools
+  - trading
+  - finance


### PR DESCRIPTION
Adds the AZPowers Skills Agent Zero plugin index entry for the public `up2itnow0822/AZPowers-Skills` repository.