### PR TITLE
feat: add readytrader_stocks plugin

### DIFF
--- a/plugins/readytrader_stocks/index.yaml
+++ b/plugins/readytrader_stocks/index.yaml
@@ -1,0 +1,8 @@
+title: ReadyTrader Stocks
+description: Connect your agent to stock markets via the ReadyTrader-Stocks MCP server. Quotes, OHLCV, fundamentals, sentiment, market regime, and paper or live trades through Alpaca.
+github: https://github.com/up2itnow0822/a0-readytrader-stocks-plugin
+tags:
+  - tools
+  - api
+  - integration
+  - automation


### PR DESCRIPTION
## Plugin: ReadyTrader Stocks

Connect your agent to stock markets via the ReadyTrader-Stocks MCP server. Quotes, OHLCV, fundamentals, sentiment, market regime, and paper or live trades through Alpaca.

- GitHub: https://github.com/up2itnow0822/a0-readytrader-stocks-plugin
- Tags: tools, api, integration, automation

This plugin has passed full CI (tests + py_compile + plugin.yaml schema) and was prepared following the BMAD Adversarial Review process.