### PR TITLE
feat: add readytrader_forex plugin

### DIFF
--- a/plugins/readytrader_forex/index.yaml
+++ b/plugins/readytrader_forex/index.yaml
@@ -1,0 +1,8 @@
+title: ReadyTrader FOREX
+description: Connect your agent to forex markets via the ReadyTrader-FOREX MCP server. Live prices, economic calendar, market regime, and paper or live trades on major currency pairs.
+github: https://github.com/up2itnow0822/a0-readytrader-forex-plugin
+tags:
+  - tools
+  - api
+  - integration
+  - automation


### PR DESCRIPTION
## Plugin: ReadyTrader FOREX

Connect your agent to forex markets via the ReadyTrader-FOREX MCP server. Live prices, economic calendar, market regime, and paper or live trades on major currency pairs.

- GitHub: https://github.com/up2itnow0822/a0-readytrader-forex-plugin
- Tags: tools, api, integration, automation

This plugin has passed full CI (tests + py_compile + plugin.yaml schema) and was prepared following the BMAD Adversarial Review process.