### PR TITLE
feat: add readytrader_crypto plugin

### DIFF
--- a/plugins/readytrader_crypto/index.yaml
+++ b/plugins/readytrader_crypto/index.yaml
@@ -1,0 +1,8 @@
+title: ReadyTrader Crypto
+description: Connect your agent to cryptocurrency markets via the ReadyTrader-Crypto MCP server. Prices, backtests, risk management, and paper or live trades across Binance, Coinbase, Kraken, OKX, and Bybit.
+github: https://github.com/up2itnow0822/a0-readytrader-crypto-plugin
+tags:
+  - tools
+  - api
+  - integration
+  - automation


### PR DESCRIPTION
## Plugin: ReadyTrader Crypto

Connect your agent to cryptocurrency markets via the ReadyTrader-Crypto MCP server. Prices, backtests, risk management, and paper or live trades across Binance, Coinbase, Kraken, OKX, and Bybit.

- GitHub: https://github.com/up2itnow0822/a0-readytrader-crypto-plugin
- Tags: tools, api, integration, automation

This plugin has passed full CI (tests + py_compile + plugin.yaml schema) and was prepared following the BMAD Adversarial Review process.