### PR TITLE
Add 9Router plugin

### DIFF
--- a/plugins/9router/index.yaml
+++ b/plugins/9router/index.yaml
@@ -1,0 +1,9 @@
+title: 9Router
+description: Smart AI model router with 3-tier fallback (subscription → cheap → free) that minimizes costs and prevents coding interruptions across 40+ providers and 100+ models
+github: https://github.com/decolua/9router
+tags:
+  - llm
+  - api
+  - automation
+  - cli
+  - integration


### PR DESCRIPTION
Add 9Router plugin - Smart AI model router with 3-tier fallback (subscription → cheap → free) that minimizes costs and prevents coding interruptions across 40+ providers and 100+ models.

**Note:** The CI validation will fail until the [9router repository](https://github.com/decolua/9router) adds a `plugin.yaml` file at its root with a `name: 9router` field. This is a required validation step for the a0-plugins index.

Plugin details:
- GitHub: https://github.com/decolua/9router
- Tags: llm, api, automation, cli, integration

🤖 Generated with [Claude Code](https://claude.ai/code)