### PR TITLE
Add LinkedIn plugin to community index

### DIFF
--- a/plugins/linkedin/index.yaml
+++ b/plugins/linkedin/index.yaml
@@ -1,0 +1,9 @@
+title: LinkedIn
+description: Manage approved LinkedIn posting workflows in Agent Zero, including account checks, text post publishing, and recent post retrieval.
+github: https://github.com/gshock/a0-linkedin
+tags:
+  - social
+  - linkedin
+  - publishing
+  - marketing
+  - api


### PR DESCRIPTION
## Summary
Adds the LinkedIn plugin to the Agent Zero community plugin index.

## Plugin repo
https://github.com/gshock/a0-linkedin

## Included metadata
- Plugin name: `linkedin`
- Index path: `plugins/linkedin/index.yaml`
- Release version: `v0.1.0`

## What this plugin does
The LinkedIn plugin supports approved LinkedIn posting workflows in Agent Zero, including:
- account and readiness checks
- personal and organization routing
- text post publishing
- recent post retrieval where supported by LinkedIn scopes and permissions

## Release status
This submission is for **v0.1.0**.

Current validation status:
- Personal posting has been tested successfully
- Organization posting support is included in the plugin design
- LinkedIn organization posting verification is still pending, so organization live validation is not yet complete

For this release, organization-related functionality should be treated as provisional and dependent on LinkedIn app approval, token scopes, and organization role permissions.

## Repo checks
- Runtime manifest is included at the plugin repo root
- `plugin.yaml` name matches the index folder name: `linkedin`
- `LICENSE` is included at the plugin repo root
- README is included at the plugin repo root

## Notes
This plugin is API-first and intentionally conservative. It is designed to fail clearly when required scopes, identities, or organization permissions are missing rather than guessing or auto-posting.
