### PR TITLE
Add Android Control plugin

### DIFF
--- a/plugins/droidclaw/index.yaml
+++ b/plugins/droidclaw/index.yaml
@@ -1,0 +1,9 @@
+title: Android Control
+description: Control Android devices from Agent Zero with ADB pairing, screenshots, quick actions, and LLM-guided task execution.
+github: https://github.com/Omni-NexusAI/android-control
+tags:
+  - automation
+  - tools
+  - agents
+  - integration
+  - ui


### PR DESCRIPTION
﻿## Summary

Adds the Android Control (`droidclaw`) plugin listing to the A0 plugin marketplace index.

## Plugin repository

https://github.com/Omni-NexusAI/android-control

The standalone plugin repository contains `plugin.yaml` at the repository root with `name: droidclaw`, plus `LICENSE`, `requirements.txt`, and the validated plugin package.

## Validation

- Ran the repository validator locally: `scripts/validate_plugin_submission.py`
- Validation result: `Validation passed for plugin: droidclaw`
- Verified public root `plugin.yaml` is reachable from `https://raw.githubusercontent.com/Omni-NexusAI/android-control/main/plugin.yaml`
- Verified standalone plugin package includes `LICENSE`
- Verified `requirements.txt` includes `zeroconf` and `cryptography`
- Verified standalone `thumbnail.png` is square and under 20 KB
