### PR TITLE
feat: add a0_localai

### DIFF
--- a/plugins/a0_localai/index.yaml
+++ b/plugins/a0_localai/index.yaml
@@ -1,0 +1,7 @@
+title: A0 LocalAI
+description: Adds LocalAI as an OpenAI-compatible LLM provider for Agent Zero chat and embedding models.
+github: https://github.com/neurocis/A0_LocalAI
+tags:
+  - llm
+  - integration
+  - api


### PR DESCRIPTION
## Plugin: A0 LocalAI

Adds **LocalAI** as an OpenAI-compatible LLM provider for Agent Zero chat and embedding models.

- GitHub: https://github.com/neurocis/A0_LocalAI
- Tags: llm, integration, api

The plugin contributes `chat.localai` and `embedding.localai` provider definitions via `conf/model_providers.yaml`. LiteLLM `openai`-compatible mode is used so non-registry LocalAI model ids work. Endpoint is configured per-model in the Model Configuration UI (no API base hardcoded).