### PR TITLE
Add a0_lemonade plugin

### DIFF
--- a/plugins/a0_lemonade/index.yaml
+++ b/plugins/a0_lemonade/index.yaml
@@ -1,5 +1,5 @@
 title: A0 Lemonade
-description: Adds Lemonade as an OpenAI-compatible LLM provider for chat and embedding models.
+description: Adds Lemonade Server as an OpenAI-compatible LLM provider for chat and embedding models.
 github: https://github.com/neurocis/A0_Lemonade
 tags:
   - llm

--- a/plugins/a0_lemonade/index.yaml
+++ b/plugins/a0_lemonade/index.yaml
@@ -1,0 +1,8 @@
+title: A0 Lemonade
+description: Adds Lemonade as an OpenAI-compatible LLM provider for chat and embedding models.
+github: https://github.com/neurocis/A0_Lemonade
+tags:
+  - llm
+  - embeddings
+  - integration
+  - api


### PR DESCRIPTION
Repository: https://github.com/neurocis/A0_Lemonade
Provider: Lemonade — OpenAI-compatible LLM provider for both chat and embedding models
LiteLLM: uses litellm_provider: openai with custom_llm_provider: openai so arbitrary local Lemonade model names work
No hardcoded api_base — user configures the endpoint per-model via Model Configuration
License: MIT