### PR TITLE
feat: add open_notebook plugin

### DIFF
--- a/plugins/open_notebook/index.yaml
+++ b/plugins/open_notebook/index.yaml
@@ -9,7 +9,5 @@ tags:
   - web
 screenshots:
   - https://raw.githubusercontent.com/twilso24/open_notebook_agent_zero/main/docs/screenshot-notebooks.png
-  - https://raw.githubusercontent.com/twilso24/open_notebook_agent_zero/main/docs/screenshot-chat.png
   - https://raw.githubusercontent.com/twilso24/open_notebook_agent_zero/main/docs/screenshot-podcasts.png
-  - https://raw.githubusercontent.com/twilso24/open_notebook_agent_zero/main/docs/screenshot-notes.png
   - https://raw.githubusercontent.com/twilso24/open_notebook_agent_zero/main/docs/screenshot-sources.png

--- a/plugins/open_notebook/index.yaml
+++ b/plugins/open_notebook/index.yaml
@@ -1,0 +1,15 @@
+title: Open Notebook
+description: Connect Agent Zero to Open Notebook for notebook browsing, source management, RAG queries, notes, podcasts, and a right-canvas knowledge panel.
+github: https://github.com/twilso24/open_notebook_agent_zero
+tags:
+  - integration
+  - tools
+  - llm
+  - search
+  - web
+screenshots:
+  - https://raw.githubusercontent.com/twilso24/open_notebook_agent_zero/main/docs/screenshot-notebooks.png
+  - https://raw.githubusercontent.com/twilso24/open_notebook_agent_zero/main/docs/screenshot-chat.png
+  - https://raw.githubusercontent.com/twilso24/open_notebook_agent_zero/main/docs/screenshot-podcasts.png
+  - https://raw.githubusercontent.com/twilso24/open_notebook_agent_zero/main/docs/screenshot-notes.png
+  - https://raw.githubusercontent.com/twilso24/open_notebook_agent_zero/main/docs/screenshot-sources.png


### PR DESCRIPTION
Connect Agent Zero to Open Notebook for notebook browsing, source management, name-based lookup, notes, podcasts, and a right-canvas knowledge panel.

- **GitHub**: https://github.com/twilso24/open_notebook_agent_zero
- **Tags**: integration, tools, llm, knowledge, web

### What’s included
- Notebook browsing with ID visibility in the browse view
- Name-based notebook resolution across tools
- Parameter aliases for more natural tool usage
- Fully working CRUD flows for sources and notes
- Podcast generation support
- UI cleanup and scroll fixes in the right-canvas panel
- Removed broken global search UI
- Removed unused Cloudflare tunnel support and related references
- Removed obsolete search/ask beta feature references

### Checklist
- [x] `index.yaml` in `plugins/open_notebook/`
- [x] Folder name matches `^[a-z0-9_]+$`
- [x] Remote `plugin.yaml` has `name: open_notebook` matching folder name
- [x] Remote `LICENSE` exists at repo root (MIT)
- [x] Remote `README.md` present
- [x] Tags from TAGS.md (max 5)
- [x] No duplicate in existing index
