### PR TITLE
feat: add requests_per_day

### DIFF
--- a/plugins/requests_per_day/index.yaml
+++ b/plugins/requests_per_day/index.yaml
@@ -1,0 +1,6 @@
+title: Requests per Day
+description: A simple extension to agent0's dashboard to track requests in the last 24 hours.
+github: https://github.com/alxfu/a0-requests-per-day
+tags:
+  - dashboard
+  - metrics


### PR DESCRIPTION
## Plugin: Requests per Day

A simple extension to agent0's dashboard to track requests in the last 24 hours.

- GitHub: https://github.com/alxfu/a0-requests-per-day
- Tags: dashboard, metrics