### PR TITLE
feat: add llm_usage_tracker

### DIFF
--- a/plugins/llm_usage_tracker/index.yaml
+++ b/plugins/llm_usage_tracker/index.yaml
@@ -1,0 +1,6 @@
+title: LLM Usage Tracker
+description: A simple extension to agent0's dashboard to track requests and volume in the last 24 hours.
+github: https://github.com/alxfu/a0-llm-usage-tracker
+tags:
+  - dashboard
+  - metrics


### PR DESCRIPTION
## Plugin: LLM Usage Tracker

A simple extension to agent0's dashboard to track requests and volume in the last 24 hours.

- GitHub: https://github.com/alxfu/a0-llm-usage-tracker
- Tags: dashboard, metrics