### PR TITLE
feat: add kokoro_tts plugin

### DIFF
--- a/plugins/kokoro_tts/index.yaml
+++ b/plugins/kokoro_tts/index.yaml
@@ -1,0 +1,7 @@
+title: Kokoro TTS
+description: Kokoro text-to-speech plugin with voice dropdown menus, blend voice synthesis (up to 3 voices with weights summing to 1.0), manual mode, and browser TTS fallback.
+github: https://github.com/twilso24/agent-zero-kokoro-tts
+tags:
+  - tools
+  - agents
+  - automation


### PR DESCRIPTION
## Plugin: Kokoro TTS

Kokoro text-to-speech plugin with voice dropdown menus, blend voice synthesis (up to 3 voices with weights summing to 1.0), manual mode, and browser TTS fallback.

- GitHub: https://github.com/twilso24/agent-zero-kokoro-tts
- Tags: tools, agents, automation

### Features
- 54 voices across 17 language/gender groups
- Blend up to 3 voices with configurable weights
- Manual voice string input mode
- Native Kokoro comma-separated voice blending
- Speed control
- Browser TTS fallback when disabled
