### PR TITLE
feat: add music_generation plugin

### DIFF
--- a/plugins/music_generation/index.yaml
+++ b/plugins/music_generation/index.yaml
@@ -1,0 +1,14 @@
+title: Music Generation
+description: >-
+  Generate music from text prompts using Google Lyria 3 Pro via OpenRouter.
+  Create original compositions with control over genre, instrumentation, mood,
+  tempo, key, and structure. Streams audio in real-time via SSE. Outputs WAV or
+  MP3 (auto-detected). Uses Agent Zero's existing OpenRouter API key — no
+  additional setup required.
+github: https://github.com/Mustard5/music_generation
+tags:
+  - audio
+  - music
+  - generation
+  - api
+  - openrouter


### PR DESCRIPTION
## Plugin: Music Generation

Generate music from text prompts using Google Lyria 3 Pro via OpenRouter.

- **GitHub**: https://github.com/Mustard5/music_generation
- **Tags**: audio, music, generation, api, openrouter

### What it does

Sends a natural language prompt to the Lyria 3 Pro model via OpenRouter and streams back an MP3/WAV audio file using SSE. Uses Agent Zero's existing `API_KEY_OPENROUTER` — no additional signup or configuration required.

### Tested

Original cello composition and jazz trio tracks generated and verified working. MP3 format auto-detected from RIFF/ID3 magic bytes.