### PR TITLE
feat: add a0_vision_fallback plugin

### DIFF
--- a/plugins/a0_vision_fallback/index.yaml
+++ b/plugins/a0_vision_fallback/index.yaml
@@ -1,0 +1,15 @@
+title: Vision Fallback
+description: >-
+  Routes image analysis to a dedicated vision model when the main chat model
+  doesn't support vision. Intercepts images before they reach the LLM, sends
+  them to a configurable vision model (via LiteLLM), and replaces the image
+  with a text description. Works with any text-only model like glm-5.2,
+  deepseek, or llama3. Features auto API key detection from .env, hash-based
+  cache, and dark mode UI.
+github: https://github.com/lelabdev/a0-vision-fallback
+tags:
+  - llm
+  - tools
+  - vision
+  - integration
+  - agents


### PR DESCRIPTION
## Vision Fallback Plugin

Routes image analysis to a dedicated vision model when the main chat model does not support vision.

### How it works
- Extension hook intercepts images before they reach the LLM
- Sends each image to a configurable vision model (LiteLLM)
- Replaces image blocks with text descriptions
- Main chat model receives only text

### Features
- Works with any text-only model (glm-5.2, deepseek, llama3...)
- Auto-resolves API keys from Agent Zero .env
- Hash-based cache to avoid duplicate API calls
- Dark mode compatible UI

- GitHub: https://github.com/lelabdev/a0-vision-fallback
- Tags: llm, tools, vision, integration, agents