### PR TITLE
Add LLM API Visor plugin

### DIFF
--- a/plugins/a0_llm_api_visor/index.yaml
+++ b/plugins/a0_llm_api_visor/index.yaml
@@ -1,0 +1,13 @@
+title: LLM API Visor
+description: Sidebar visor for Agent Zero LLM API wallet credits, quota multiplier, local usage insights, and dashboard shortcuts.
+github: https://github.com/3clyp50/a0_llm_api_visor
+tags:
+  - llm
+  - api
+  - ui
+  - monitoring
+screenshots:
+  - https://raw.githubusercontent.com/3clyp50/a0_llm_api_visor/main/screenshots/visor.png
+  - https://raw.githubusercontent.com/3clyp50/a0_llm_api_visor/main/screenshots/settings.png
+  - https://raw.githubusercontent.com/3clyp50/a0_llm_api_visor/main/screenshots/insights-overview.png
+  - https://raw.githubusercontent.com/3clyp50/a0_llm_api_visor/main/screenshots/insights-models.png


### PR DESCRIPTION
## Summary
- Register the a0_llm_api_visor community plugin
- Link the published standalone repo: https://github.com/3clyp50/a0_llm_api_visor
- Include four Plugin Hub screenshots from the plugin repo

## Validation
- BASE_SHA=83facb648b4df2ac08f98122172c8183a8d9258d HEAD_SHA=4e5ef6b36f90124ff7c9dee05e56a3ab33eacfb0 PR_AUTHOR=3clyp50 python scripts/validate_plugin_submission.py
- Result: Validation passed for plugin: a0_llm_api_visor