### PR TITLE
Update Tree Ring Memory lifecycle hooks

### DIFF
--- a/plugins/tree_ring_memory/index.yaml
+++ b/plugins/tree_ring_memory/index.yaml
@@ -1,5 +1,5 @@
 title: Tree Ring Memory
-description: Rust-native lifecycle memory for Agent Zero with evidence-aware recall, safe legacy migration, maintenance tools, and a live ring-usage dashboard.
+description: Rust-native lifecycle memory for Agent Zero with automatic hook-based setup, validated legacy migration, evidence-aware recall, maintenance tools, and a live ring-usage dashboard.
 github: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero
 tags:
   - memory


### PR DESCRIPTION
## Summary

- update the existing `tree_ring_memory` marketplace description for plugin version 2.1.0
- document automatic hook-based setup and validated legacy migration

The installable source remains in `TerminallyLazy/tree-ring-memory-agent-zero`; its default branch now removes the manual Execute script and initializes, migrates, and audits through idempotent Agent Zero lifecycle hooks.

## Validation

- `scripts/validate_plugin_submission.py` passed against the PR base/head SHAs
- remote root `plugin.yaml` resolves with `name: tree_ring_memory` and `version: 2.1.0`
- marketplace diff is limited to `plugins/tree_ring_memory/index.yaml`
- source plugin suite: 25 passed
- live Agent Zero card reports 2.1.0 with no Execute action
