### PR TITLE
feat: add browser_session_sync plugin

### DIFF
--- a/plugins/browser_session_sync/index.yaml
+++ b/plugins/browser_session_sync/index.yaml
@@ -1,0 +1,9 @@
+title: Browser Session Sync
+description: WIP plugin for preserving native Browser tabs, cookies, and localStorage across A0 restarts with boot-gated restore and debounced saves.
+github: https://github.com/Omni-NexusAI/a0-plugins
+tags:
+  - browser
+  - storage
+  - workflow
+  - automation
+  - ui

--- a/plugins/droidclaw/index.yaml
+++ b/plugins/droidclaw/index.yaml
@@ -1,0 +1,8 @@
+title: Android Control
+description: Control Android devices through ADB with QR/manual pairing, Tailscale remote-device connection, screenshots, and agent-guided app automation.
+github: https://github.com/Omni-NexusAI/android-control
+tags:
+  - automation
+  - tools
+  - integration
+  - development


### PR DESCRIPTION
## Plugin: Browser Session Sync

Persists native Browser tabs, cookies, and localStorage across container restarts with one-shot startup restore and debounced live-state tracking.

- GitHub: https://github.com/Omni-NexusAI/a0-plugins
- Tags: browser, storage, workflow, automation, ui
- Version: 1.4.1 (includes guard for runtime-start restore so internal errors are logged instead of breaking the Browser UI JSON parse)

Submitted via fork Omni-NexusAI/a0-plugins-android-control branch add-browser-session-sync.