### PR TITLE
Refresh GLiNER2 marketplace listing

### DIFF
--- a/plugins/gliner2/index.yaml
+++ b/plugins/gliner2/index.yaml
@@ -1,9 +1,9 @@
-title: gliner2
-description: Gliner2 is a direct `gliner2_extract` tool for entities, classification, JSON extraction, and relations. A framework extension that can replace eligible memory utility-model calls with GLiNER2 entity extraction and exposes framework hooks for memory keyword extraction and knowledge metadata enrichment.
+title: GLiNER2
+description: GLiNER2 adds local CPU/CUDA or hosted structured inference for entities, classification, typed JSON, and relations, plus bounded Agent Zero memory enrichment, safe Utility fallback, runtime diagnostics, and an in-panel test bench.
 github: https://github.com/a0-community-plugins/gliner2
 tags:
   - tools
   - memory
   - agents
-  - integration
-  - development
+  - api
+  - ui


### PR DESCRIPTION
## Plugin

GLiNER2 2.0.0 — https://github.com/a0-community-plugins/gliner2

## Listing update

- uses the canonical GLiNER2 display name
- reflects local CPU/CUDA and hosted API routes
- calls out entities, classification, typed JSON, relations, bounded memory enrichment, diagnostics, and the built-in test bench
- refreshes tags to match the current tool, memory, API, and UI surface

## Verification

- official submission validator passed locally
- source plugin is merged to `main`
- source CI is green on Python 3.11, 3.12, and 3.13
- only `plugins/gliner2/index.yaml` changes
