### PR TITLE
Add Mermaid Diagrams plugin

### DIFF
--- a/plugins/mermaid_diagrams/index.yaml
+++ b/plugins/mermaid_diagrams/index.yaml
@@ -1,0 +1,12 @@
+title: Mermaid Diagrams
+description: >-
+  Renders Mermaid code blocks as interactive SVG diagrams directly in the chat UI, so flowcharts,
+  sequence diagrams, class and ER diagrams, state machines, mindmaps and timelines appear as
+  pictures instead of raw syntax. Ships a skill that teaches the agent Mermaid syntax plus a
+  behavioural nudge to reach for a diagram when a user asks to be shown a process, architecture
+  or set of relationships.
+github: https://github.com/agent-zero-plugins/agent-zero-plugin-mermaid-diagrams
+tags:
+  - ui
+  - documents
+  - workflow


### PR DESCRIPTION
Adds `plugins/mermaid_diagrams/index.yaml`.

Renders Mermaid code blocks as interactive SVG diagrams in the chat UI (flowcharts, sequence, class/ER, state, mindmaps, timelines), with a click-to-zoom viewer. Ships a skill teaching the agent Mermaid syntax plus a behavioural nudge to reach for a diagram when a visual explanation helps.

- Repo: https://github.com/agent-zero-plugins/agent-zero-plugin-mermaid-diagrams (public, Apache-2.0)
- Root `plugin.yaml` has `name: mermaid_diagrams`, matching the folder name
- No thumbnail included: the upstream asset is a 16x16 placeholder, so the auto-generated fallback will look better