### PR TITLE
Update Tree Ring Memory 3.1 marketplace listing

### DIFF
--- a/plugins/tree_ring_memory/index.yaml
+++ b/plugins/tree_ring_memory/index.yaml
@@ -1,11 +1,11 @@
 title: Tree Ring Memory
-description: Rust-native lifecycle memory for Agent Zero with automatic hook-based setup, validated legacy migration, evidence-aware recall, maintenance tools, and a live ring-usage dashboard.
+description: Tree Ring Memory 3.1.0 integrates Agent Zero with project-local memory, explicit harness activation, shared multi-agent context, and receipt-backed proof that project recall was used.
 github: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero
 tags:
   - memory
-  - sqlite
-  - cli
-  - ui
+  - agents
+  - integration
   - workflow
+  - sqlite
 screenshots:
   - https://raw.githubusercontent.com/TerminallyLazy/tree-ring-memory-agent-zero/main/screenshots/tree-ring-memory-dashboard.png


### PR DESCRIPTION
Updates the index-only Tree Ring Memory listing for the 3.1.0 project-local activation release.

- Describes Agent Zero integration, multi-agent project context, harness activation, and receipt-backed proof.
- Keeps this marketplace change limited to `plugins/tree_ring_memory/index.yaml`.
- Validation: `scripts/validate_plugin_submission.py` passed for `tree_ring_memory`.