### PR TITLE
Add TrustedRouter Provider plugin

### DIFF
--- a/plugins/trustedrouter_provider/index.yaml
+++ b/plugins/trustedrouter_provider/index.yaml
@@ -1,0 +1,6 @@
+title: TrustedRouter Provider
+description: Adds TrustedRouter as an OpenAI-compatible chat and embedding provider. One key reaches OpenAI, Anthropic, Google, DeepSeek and others, with per-request routing and failover. Routing policies constrain which upstreams may serve a request - zdr for no-retention providers, e2e for confidential compute, eu for EU-hosted.
+github: https://github.com/Lore-Hex/agent-zero-trustedrouter
+tags:
+  - llm
+  - integration


### PR DESCRIPTION
Adds the TrustedRouter provider plugin: https://github.com/Lore-Hex/agent-zero-trustedrouter

TrustedRouter is an OpenAI-compatible router, so the plugin is config-only — a `conf/model_providers.yaml` registering `trustedrouter` for chat and embeddings. Provider ID maps to `TRUSTEDROUTER_API_KEY` automatically.

One implementation note: it sets `litellm_provider: openai` with an explicit `api_base` rather than litellm's own `trustedrouter` provider. That provider strips the first path segment as the prefix, so `trustedrouter/auto` would reach the API as bare `auto`, which TrustedRouter rejects. Going through the OpenAI-compatible provider forwards the namespaced id unchanged.

Follows up on agent0ai/agent-zero#1704, where @3clyp50 asked for this to be a community plugin instead of a core change.
