### PR TITLE
Add Chat History plugin

### DIFF
--- a/plugins/chat_history/index.yaml
+++ b/plugins/chat_history/index.yaml
@@ -1,0 +1,14 @@
+title: Chat History
+description: 'Queryable chat history for every conversation (main chat, subagents,
+  background jobs) in an embedded Postgres database (pg0, no extra containers): full-text
+  and semantic search, context inspection, and a live replica that never loses messages
+  to compaction. Embeddings use the embedding model already configured in model settings.
+  Optional Continuous Mode turns the primary chat into one infinite rolling conversation
+  with compaction summaries archived to a durable deck.'
+github: https://github.com/Nicfox77/a0-plugin-chat-history
+tags:
+- storage
+- database
+- search
+- agents
+- ui


### PR DESCRIPTION
## Summary

Adds `chat_history` to the Agent Zero Plugin Index.

Plugin repository: https://github.com/Nicfox77/a0-plugin-chat-history

## Validation

- public repository and root `plugin.yaml` verified
- manifest name matches `plugins/chat_history`
- official `validate_plugin_submission.py` check passes
- standalone publication and test suite passed before release
