### PR TITLE
Add Code Index plugin

### DIFF
--- a/plugins/code_index/index.yaml
+++ b/plugins/code_index/index.yaml
@@ -1,0 +1,13 @@
+title: Code Index
+description: 'Automatic semantic code index for Agent Zero projects. Detects every
+  git repository in the active project folder (whole folder when there are none),
+  indexes incrementally on startup and file changes, and ships the code_search tool:
+  natural-language and symbol search across all repos with an optional repository
+  filter. Embeddings use the embedding model configured in Agent Zero model settings.'
+github: https://github.com/Nicfox77/a0-plugin-code-index
+tags:
+- development
+- search
+- embeddings
+- rag
+- tools


### PR DESCRIPTION
## Summary

Adds `code_index` to the Agent Zero Plugin Index.

Plugin repository: https://github.com/Nicfox77/a0-plugin-code-index

## Validation

- public repository and root `plugin.yaml` verified
- manifest name matches `plugins/code_index`
- official `validate_plugin_submission.py` check passes
- standalone publication and test suite passed before release
