### PR TITLE
Add Custom Providers plugin

### DIFF
--- a/plugins/custom_providers/index.yaml
+++ b/plugins/custom_providers/index.yaml
@@ -1,0 +1,11 @@
+title: Custom Providers
+description: Manage custom OpenAI-compatible model providers. Add, edit, delete, and
+  test custom LLM endpoints that integrate seamlessly with the model configuration
+  dropdowns.
+github: https://github.com/Nicfox77/a0-plugin-custom-providers
+tags:
+- llm
+- api
+- ui
+- integration
+- secrets


### PR DESCRIPTION
## Summary

Adds `custom_providers` to the Agent Zero Plugin Index.

Plugin repository: https://github.com/Nicfox77/a0-plugin-custom-providers

## Validation

- public repository and root `plugin.yaml` verified
- manifest name matches `plugins/custom_providers`
- official `validate_plugin_submission.py` check passes
- standalone publication and test suite passed before release
