### PR TITLE
Add Hindsight Memory plugin

### DIFF
--- a/plugins/hindsight_memory/index.yaml
+++ b/plugins/hindsight_memory/index.yaml
@@ -1,0 +1,11 @@
+title: Hindsight Memory
+description: Fully managed Hindsight memory with embedded PostgreSQL, automatic API
+  installation, personal continuity, project-scoped subagent memory, and bounded recall
+  context.
+github: https://github.com/Nicfox77/a0-plugin-hindsight-memory
+tags:
+- memory
+- rag
+- vector-db
+- agents
+- postgres


### PR DESCRIPTION
## Summary

Adds `hindsight_memory` to the Agent Zero Plugin Index.

Plugin repository: https://github.com/Nicfox77/a0-plugin-hindsight-memory

## Validation

- public repository and root `plugin.yaml` verified
- manifest name matches `plugins/hindsight_memory`
- official `validate_plugin_submission.py` check passes
- standalone publication and test suite passed before release
