### PR TITLE
Add LLM Transport plugin

### DIFF
--- a/plugins/llm_transport/index.yaml
+++ b/plugins/llm_transport/index.yaml
@@ -1,0 +1,11 @@
+title: LLM Transport
+description: Portable model transport improvements for Responses, Chat Completions,
+  and Anthropic Messages, with normalized reasoning, native tools, retries, media
+  handling, and provider-safe state replay.
+github: https://github.com/Nicfox77/a0-plugin-llm-transport
+tags:
+- llm
+- api
+- tools
+- framework
+- monitoring


### PR DESCRIPTION
## Summary

Adds `llm_transport` to the Agent Zero Plugin Index.

Plugin repository: https://github.com/Nicfox77/a0-plugin-llm-transport

## Validation

- public repository and root `plugin.yaml` verified
- manifest name matches `plugins/llm_transport`
- official `validate_plugin_submission.py` check passes
- standalone publication and test suite passed before release
