### PR TITLE
Add Heartbeat Scheduler plugin

### DIFF
--- a/plugins/proactive_heartbeat/index.yaml
+++ b/plugins/proactive_heartbeat/index.yaml
@@ -1,0 +1,11 @@
+title: Heartbeat Scheduler
+description: Autonomous heartbeat — wakes the agent after an idle period for silent
+  maintenance work (notes queue, journal, maintenance checks). Replaces the external
+  systemd daemon with an in-process scheduler.
+github: https://github.com/Nicfox77/a0-plugin-proactive-heartbeat
+tags:
+- agents
+- automation
+- scheduling
+- monitoring
+- workflow


### PR DESCRIPTION
## Summary

Adds `proactive_heartbeat` to the Agent Zero Plugin Index.

Plugin repository: https://github.com/Nicfox77/a0-plugin-proactive-heartbeat

## Validation

- public repository and root `plugin.yaml` verified
- manifest name matches `plugins/proactive_heartbeat`
- official `validate_plugin_submission.py` check passes
- standalone publication and test suite passed before release
