### PR TITLE
Add Installable Web App (PWA) plugin

### DIFF
--- a/plugins/pwa_installable/index.yaml
+++ b/plugins/pwa_installable/index.yaml
@@ -1,0 +1,10 @@
+title: Installable Web App (PWA)
+description: Makes the web UI installable with a public manifest, PNG icons, and mobile
+  home-screen metadata while preserving Agent Zero's versioned service worker. Works
+  through the tailscale-serve HTTPS frontend on desktop and mobile, including iOS
+  home-screen install.
+github: https://github.com/Nicfox77/a0-plugin-pwa-installable
+tags:
+- ui
+- web
+- integration


### PR DESCRIPTION
## Summary

Adds `pwa_installable` to the Agent Zero Plugin Index.

Plugin repository: https://github.com/Nicfox77/a0-plugin-pwa-installable

## Validation

- public repository and root `plugin.yaml` verified
- manifest name matches `plugins/pwa_installable`
- official `validate_plugin_submission.py` check passes
- standalone publication and test suite passed before release
