### PR TITLE
Add Response Attachments plugin

### DIFF
--- a/plugins/response_attachments/index.yaml
+++ b/plugins/response_attachments/index.yaml
@@ -1,0 +1,8 @@
+title: Response Attachments
+description: Extract framework file markers into response attachments without core
+  patches.
+github: https://github.com/Nicfox77/a0-plugin-response-attachments
+tags:
+- files
+- tools
+- ui


### PR DESCRIPTION
## Summary

Adds `response_attachments` to the Agent Zero Plugin Index.

Plugin repository: https://github.com/Nicfox77/a0-plugin-response-attachments

## Validation

- public repository and root `plugin.yaml` verified
- manifest name matches `plugins/response_attachments`
- official `validate_plugin_submission.py` check passes
- standalone publication and test suite passed before release
