### PR TITLE
Add Skills Lifecycle plugin

### DIFF
--- a/plugins/skills_autoload/index.yaml
+++ b/plugins/skills_autoload/index.yaml
@@ -1,6 +1,7 @@
-title: Skills Auto-Unload
-description: Automatically unloads stale skills after a configurable number of turns
-  and provides explicit skill cleanup controls.
+title: Skills Lifecycle
+description: >-
+  Cache-friendly skill loading, logical unload, and compaction-time instruction
+  eviction for stock and rolling Agent Zero chat history.
 github: https://github.com/Nicfox77/a0-plugin-skills-autoload
 tags:
 - prompting

--- a/plugins/skills_autoload/index.yaml
+++ b/plugins/skills_autoload/index.yaml
@@ -1,0 +1,8 @@
+title: Skills Auto-Unload
+description: Automatically unloads stale skills after a configurable number of turns
+  and provides explicit skill cleanup controls.
+github: https://github.com/Nicfox77/a0-plugin-skills-autoload
+tags:
+- prompting
+- agents
+- workflow


### PR DESCRIPTION
## Summary

Adds `skills_autoload` to the Agent Zero Plugin Index. The plugin provides cache-friendly durable skill loading, immediate logical unload, and compaction-time instruction eviction for stock and rolling Agent Zero history.

Plugin repository: https://github.com/Nicfox77/a0-plugin-skills-autoload

## Validation

- public standalone repository and root `plugin.yaml` verified
- stock automatic compression, stock manual compaction, and optional Continuous Mode adapters covered
- native call/result pairing and standalone replay covered
- 630 deployment plugin tests passed
- live Agent Zero restart installed all adapters without lifecycle errors