### PR TITLE
Add Subagents plugin

### DIFF
--- a/plugins/subagents/index.yaml
+++ b/plugins/subagents/index.yaml
@@ -1,0 +1,11 @@
+title: Subagents
+description: Durable background subagent orchestration for agents and humans, with
+  a pg0 lifecycle registry, completion callbacks, steering, cancellation, transcript
+  inspection, and a responsive WebUI control center.
+github: https://github.com/Nicfox77/a0-plugin-subagents
+tags:
+- agents
+- jobs
+- automation
+- ui
+- workflow


### PR DESCRIPTION
## Summary

Adds `subagents` to the Agent Zero Plugin Index.

Plugin repository: https://github.com/Nicfox77/a0-plugin-subagents

## Validation

- public repository and root `plugin.yaml` verified
- manifest name matches `plugins/subagents`
- official `validate_plugin_submission.py` check passes
- standalone publication and test suite passed before release
