### PR TITLE
Add Synthetic Context plugin

### DIFF
--- a/plugins/synthetic_context/index.yaml
+++ b/plugins/synthetic_context/index.yaml
@@ -1,0 +1,12 @@
+title: Synthetic Context
+description: 'Renders runtime-injected context (Agent Zero extras: memory recall decks,
+  summary decks, heartbeat and job context) as automatic tool results instead of a
+  trailing user message. The model receives each block as the output of a framework-only
+  background tool that is never advertised and cannot be called — passive context
+  without fake user messages.'
+github: https://github.com/Nicfox77/a0-plugin-synthetic-context
+tags:
+- prompting
+- tools
+- framework
+- agents


### PR DESCRIPTION
## Summary

Adds `synthetic_context` to the Agent Zero Plugin Index.

Plugin repository: https://github.com/Nicfox77/a0-plugin-synthetic-context

## Validation

- public repository and root `plugin.yaml` verified
- manifest name matches `plugins/synthetic_context`
- official `validate_plugin_submission.py` check passes
- standalone publication and test suite passed before release
