### PR TITLE
Add Vision Router plugin

### DIFF
--- a/plugins/vision_router/index.yaml
+++ b/plugins/vision_router/index.yaml
@@ -1,0 +1,9 @@
+title: Vision Router
+description: Transparently routes image attachments to native vision models or a cached
+  vision fallback.
+github: https://github.com/Nicfox77/a0-plugin-vision-router
+tags:
+- image
+- llm
+- tools
+- api


### PR DESCRIPTION
## Summary

Adds `vision_router` to the Agent Zero Plugin Index.

Plugin repository: https://github.com/Nicfox77/a0-plugin-vision-router

## Validation

- public repository and root `plugin.yaml` verified
- manifest name matches `plugins/vision_router`
- official `validate_plugin_submission.py` check passes
- standalone publication and test suite passed before release
