### PR TITLE
Update api_rotation_by_kame: repo renamed to kame-api-rotation-for-agent-zero (1.2.0)

### DIFF
--- a/plugins/api_rotation_by_kame/index.yaml
+++ b/plugins/api_rotation_by_kame/index.yaml
@@ -1,6 +1,6 @@
 title: KAME — API Rotation & Stability Engine
-description: KAME rotates API keys to avoid 429 errors, cooldown exhausted keys, respect retry delays, and route around provider outages during long agent runs.
-github: https://github.com/Kame696/kame-api-engine
+description: KAME rotates API keys to avoid 429 errors, cooldown exhausted keys, respect retry delays, and route around provider outages during long agent runs. When every key is cooling it waits for the exact moment one recovers, and says so in the chat instead of looking frozen.
+github: https://github.com/Kame696/kame-api-rotation-for-agent-zero
 tags:
   - api
   - llm


### PR DESCRIPTION
Repository was renamed from \`kame-api-engine\` to \`kame-api-rotation-for-agent-zero\` (GitHub redirects the old URL, but the catalog stores the URL as plain text, so it needs updating here too). Also refreshes the description to mention the 1.2.0 wait-notice behavior.

Changed fields only:
- \`github:\` -> new repo URL
- \`description:\` -> adds the 1.2.0 headline (262 chars, under the 500 limit)

Unchanged: \`title\`, \`tags\`, \`name\` (folder), thumbnail. This is the same plugin merged in #334, no new plugin, one folder touched.