### PR TITLE
Update Tree Ring Memory to 3.2.0

### DIFF
--- a/plugins/tree_ring_memory/index.yaml
+++ b/plugins/tree_ring_memory/index.yaml
@@ -1,5 +1,5 @@
 title: Tree Ring Memory
-description: Tree Ring Memory 3.1.0 integrates Agent Zero with project-local memory, explicit harness activation, shared multi-agent context, and receipt-backed proof that project recall was used.
+description: Tree Ring Memory 3.2.0 integrates Agent Zero with bundled Tree Ring 0.15.3, project-local memory, explicit harness activation, shared multi-agent context, and receipt-backed proof that project recall was used.
 github: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero
 tags:
   - memory


### PR DESCRIPTION
Updates the existing Tree Ring Memory marketplace entry after the source plugin 3.2.0 release.

- plugin release: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero/releases/tag/v3.2.0
- bundled CLI: Tree Ring Memory 0.15.3
- retains the same repository, tags, and screenshot
- changes only `plugins/tree_ring_memory/index.yaml`

Local submission validation passes against current upstream `main`.