### PR TITLE
Update A0 Self-Improvement for 2.0.13

### DIFF
--- a/plugins/dspy_rlm/index.yaml
+++ b/plugins/dspy_rlm/index.yaml
@@ -1,5 +1,5 @@
 title: A0 Self-Improvement
-description: Improves Agent Zero during runtime with DSPy GEPA prompt optimization, bounded RLM long-context analysis, semantic quality gates, and managed local multiprocess workers.
+description: Authority-ranked self-improvement with automatic project setup, content-free RLM/GEPA candidate work, governed activation, and a live Autopilot dashboard.
 github: https://github.com/TerminallyLazy/a0-self-improvement
 tags:
   - llm


### PR DESCRIPTION
Updates the A0 Self-Improvement catalog entry for the standalone plugin's 2.0.13 release. Every editable Settings field now synchronizes to its canonical persisted value before save and restores from that value on reopen. This fixes cooldown, cadence, replay, preview, trace, GEPA, and scheduler compatibility controls. Review and Autopilot now visibly lock required capabilities instead of presenting controls that the selected mode would overwrite. The release retains project-wide observability, automatic project setup, governed activation, and fail-closed production promotion authority.