### PR TITLE
chore: update Tree Ring Memory to 3.3.0

### DIFF
--- a/plugins/tree_ring_memory/index.yaml
+++ b/plugins/tree_ring_memory/index.yaml
@@ -1,5 +1,5 @@
 title: Tree Ring Memory
-description: Tree Ring Memory 3.2.0 integrates Agent Zero with bundled Tree Ring 0.15.3, project-local memory, explicit harness activation, shared multi-agent context, and receipt-backed proof that project recall was used.
+description: Tree Ring Memory 3.3.0 integrates Agent Zero with bundled Tree Ring 0.15.3, one-action project activation, persistent project-filtered writer context, shared multi-agent memory, and receipt-backed proof of recall.
 github: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero
 tags:
   - memory
@@ -7,5 +7,3 @@ tags:
   - integration
   - workflow
   - sqlite
-screenshots:
-  - https://raw.githubusercontent.com/TerminallyLazy/tree-ring-memory-agent-zero/main/screenshots/tree-ring-memory-dashboard.png


### PR DESCRIPTION
## Summary
- update the Tree Ring Memory catalog description to plugin 3.3.0
- advertise one-action project activation and persistent project-filtered writer context
- remove the stale screenshot that visibly reported Tree Ring 0.12.0

## Published source
- Release: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero/releases/tag/v3.3.0
- Source PR: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero/pull/10

## Validation
- `python scripts/validate_plugin_submission.py` passed against this exact commit
- the PR changes only `plugins/tree_ring_memory/index.yaml`