### PR TITLE
Update Tree Ring Memory to 3.3.1

### DIFF
--- a/plugins/tree_ring_memory/index.yaml
+++ b/plugins/tree_ring_memory/index.yaml
@@ -1,5 +1,5 @@
 title: Tree Ring Memory
-description: Tree Ring Memory 3.3.0 integrates Agent Zero with bundled Tree Ring 0.15.3, one-action project activation, persistent project-filtered writer context, shared multi-agent memory, and receipt-backed proof of recall.
+description: Tree Ring Memory 3.3.1 integrates Agent Zero with bundled Tree Ring 0.15.4, reliable one-click project activation, persistent project-level writer identity, shared multi-agent memory, and accurate receipt-backed activation status.
 github: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero
 tags:
   - memory


### PR DESCRIPTION
Updates the Tree Ring Memory Plugin Hub listing for the published 3.3.1 release:

- bundled Tree Ring 0.15.4
- reliable one-click project activation
- persistent project-level writer identity without a per-chat dropdown
- accurate receipt-backed active status after preflight

Validated with the repository submission validator.