### PR TITLE
Refresh Tree-sitter 1.1.0 Plugin Hub listing

### DIFF
--- a/plugins/tree_sitter/index.yaml
+++ b/plugins/tree_sitter/index.yaml
@@ -1,5 +1,5 @@
 title: Tree-sitter Code Intelligence
-description: Repository-scale structural intelligence for Agent Zero, with project indexing, coding context, definitions, references, queries, and syntax diagnostics.
+description: Always-on structural intelligence for Agent Zero, with automatic active-project context, incremental indexing, definitions, references, queries, syntax diagnostics, and a responsive Inspector.
 github: https://github.com/a0-community-plugins/tree_sitter
 tags:
   - development


### PR DESCRIPTION
## Summary

Tree-sitter 1.1.0 is now always-on for active Agent Zero projects: it incrementally refreshes structural context before the first model call, while retaining the redesigned Code Intelligence Inspector for manual diagnostics. This refreshes the Hub description to match the merged source release.

Source release: https://github.com/a0-community-plugins/tree_sitter/pull/3

## Verification

- local Plugin Hub submission validation passed
- source plugin version is `1.1.0` on `a0-community-plugins/tree_sitter` main
- 28-parser native runtime matrix passes