### PR TITLE
Add plugin: OpenRouter Spend Tracker

### DIFF
--- a/plugins/openrouter_spend/index.yaml
+++ b/plugins/openrouter_spend/index.yaml
@@ -1,0 +1,8 @@
+title: OpenRouter Spend Tracker
+description: Tracks OpenRouter spend per call, per chat, with rolling 3h/24h/7d/30d/90d windows and a credits bar. Exact costs via a read-only management key that is never used for inference; built-in price-table estimation as fallback. All data stays local.
+github: https://github.com/duketopceo/a0-openrouter-spend
+tags:
+  - llm
+  - monitoring
+  - tools
+  - api


### PR DESCRIPTION
Adds community plugin **OpenRouter Spend Tracker** (`openrouter_spend`).

- `plugin.yaml` at repo root carries `name: openrouter_spend` (matches folder, `^[a-z0-9_]+$`)
- MIT LICENSE + README at repo root; no runtime artifacts
- index.yaml within limits (title 24<=50, desc 245<=500, raw 396<=2000, 4 legal tags: llm/monitoring/tools/api)

Plugin source: https://github.com/LukeDuke-Bartlett/a0-openrouter-spend