### PR TITLE
Update Tree Ring Memory to 3.4.0

### DIFF
--- a/plugins/tree_ring_memory/index.yaml
+++ b/plugins/tree_ring_memory/index.yaml
@@ -1,5 +1,5 @@
 title: Tree Ring Memory
-description: Tree Ring Memory 3.3.1 integrates Agent Zero with bundled Tree Ring 0.15.4, reliable one-click project activation, persistent project-level writer identity, shared multi-agent memory, and accurate receipt-backed activation status.
+description: Tree Ring Memory 3.4.0 integrates Agent Zero with bundled Tree Ring 0.15.5, native receipt-backed lifecycle recall, bounded agent-mediated automatic capture, persistent project-level writer identity, and shared multi-agent memory.
 github: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero
 tags:
   - memory


### PR DESCRIPTION
Updates the Tree Ring Memory Plugin Hub description for the published 3.4.0 release:

- bundled Tree Ring 0.15.5 native binaries
- receipt-backed native lifecycle recall
- bounded agent-mediated automatic capture
- persistent project-level writer identity and shared multi-agent memory

Source release: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero/releases/tag/v3.4.0
Core release: https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.15.5

Only plugins/tree_ring_memory/index.yaml changes; generated index artifacts are intentionally excluded.