### PR TITLE
Update Superpowers to v2.0.0

### DIFF
--- a/plugins/superpowers/index.yaml
+++ b/plugins/superpowers/index.yaml
@@ -1,9 +1,8 @@
 title: Superpowers
-description: Complete Superpowers agentic development framework for Agent Zero with 14 verified skills, mandatory bootstrap, supervised parallel workers, SDD review loops, live methodology observability, and a visual design companion.
+description: Verified Superpowers v6.3.0 methodology adapter for Agent Zero with 14 skills, mandatory prompt-cycle bootstrap, native skill loading and delegation, conversational approvals, and locked upstream provenance.
 github: https://github.com/TerminallyLazy/agent-zero-superpowers
 tags:
   - development
   - workflow
   - agents
-  - automation
-  - ui
+  - skills


### PR DESCRIPTION
## Summary

- refresh Superpowers listing for the public v2.0.0 release
- update the bundled upstream methodology reference to Superpowers v6.3.0
- remove obsolete claims for the Methodology Map, Visual Companion runtime, custom supervisor/scheduler, and approval UI
- describe the smaller Agent Zero-native skill, delegation, and conversational-approval adapter

## Source release

- https://github.com/TerminallyLazy/agent-zero-superpowers/releases/tag/v2.0.0
- source commit: `ac6a9ac8971f3e9b4d17ee292fc5fcf56c4efab1`

## Validation

- `Validation passed for plugin: superpowers`
- public root `plugin.yaml` reports version `2.0.0`
- catalog diff is limited to `plugins/superpowers/index.yaml`