### PR TITLE
feat: add sentrysearch plugin

### DIFF
--- a/plugins/sentrysearch/index.yaml
+++ b/plugins/sentrysearch/index.yaml
@@ -1,0 +1,12 @@
+title: SentrySearch
+description: Unofficial Agent Zero fork of Soham Rajadhyaksha's SentrySearch. Index, semantically search, and play local MP4/MOV libraries with Agent Zero's configured multimodal embedding model.
+github: https://github.com/3clyp50/a0_sentrysearch
+tags:
+  - video
+  - search
+  - embeddings
+  - vector-db
+  - ui
+screenshots:
+  - https://raw.githubusercontent.com/3clyp50/a0_sentrysearch/master/docs/agent-zero-modal.webp
+  - https://raw.githubusercontent.com/3clyp50/a0_sentrysearch/master/docs/agent-zero-mobile.webp


### PR DESCRIPTION
## Plugin: SentrySearch

Adds an unofficial Agent Zero fork of [SentrySearch](https://github.com/ssrajadh/sentrysearch), originally created by Soham Rajadhyaksha, for semantic search and playback across local video libraries.

- Plugin: https://github.com/3clyp50/a0_sentrysearch
- Original: https://github.com/ssrajadh/sentrysearch
- License: Apache-2.0, with the upstream history and GitHub fork relationship preserved
- Embeddings: Agent Zero's configured multimodal embedding model; Google `gemini-embedding-2` is verified and compatible Qwen VL endpoints are identified explicitly
- UI: desktop right canvas, wide modal, and responsive mobile modal
- Live proof: indexed 2 videos / 3 chunks with Gemini, searched through ChromaDB, streamed authenticated HTTP ranges, and sought to the returned time span
- Tags: `video`, `search`, `embeddings`, `vector-db`, `ui`

Local submission validation passed against current `upstream/main`.
