### PR TITLE
Update Semantic Review Loop for 1.1.0

### DIFF
--- a/plugins/sem_review_loop/index.yaml
+++ b/plugins/sem_review_loop/index.yaml
@@ -1,5 +1,5 @@
 title: Semantic Review Loop
-description: Adds a local-only semantic diff review loop for Agent Zero with entity-level changes, bounded repair, MCP tools, and project-scoped lessons.
+description: Adds local semantic code review for Agent Zero with full working-tree coverage, guided MCP tools, entity-level changes, bounded repair, and project-scoped lessons.
 github: https://github.com/TerminallyLazy/sem-review-loop-agent-zero
 tags:
   - development


### PR DESCRIPTION
Updates the Semantic Review Loop index description for version 1.1.0.

The release expands working-tree review coverage, adds configurable payload sizing, fixes commit and range references, and makes project MCP setup visible and guided from the default Changes tab.

Plugin release: https://github.com/TerminallyLazy/sem-review-loop-agent-zero/commit/c63aee1