### PR TITLE
Update Tree-sitter index for 1.1.1

### DIFF
--- a/plugins/tree_sitter/index.yaml
+++ b/plugins/tree_sitter/index.yaml
@@ -1,5 +1,5 @@
 title: Tree-sitter Code Intelligence
-description: Always-on structural intelligence for Agent Zero, with automatic active-project context, incremental indexing, definitions, references, queries, syntax diagnostics, and a responsive Inspector.
+description: Always-on structural intelligence for Agent Zero, with reliable action-based tools, automatic project context, incremental indexing, definitions, references, queries, syntax diagnostics, and a responsive Inspector.
 github: https://github.com/a0-community-plugins/tree_sitter
 tags:
   - development


### PR DESCRIPTION
## Summary

- refresh the Tree-sitter catalog entry for the 1.1.1 release
- note reliable action-based tool dispatch in the plugin description
- trigger generated index synchronization from the upstream plugin manifest

## Verification

- official validate_plugin_submission.py passed for tree_sitter
- upstream plugin manifest reports version 1.1.1
- upstream release commit: 278864a9ae24f9429c9ad619a2a37c9e933386f6