### PR TITLE
feat: add mech_calendar plugin

### DIFF
--- a/plugins/mech_calendar/index.yaml
+++ b/plugins/mech_calendar/index.yaml
@@ -1,0 +1,9 @@
+title: Mech.Calendar
+description: Local month/week calendar with categories, export/import, JSON store, and agent handoffs that run agent tasks at event start/finish times.
+github: https://github.com/twilso24/mech_calendar
+tags:
+  - scheduling
+  - automation
+  - tools
+  - workflow
+  - ui


### PR DESCRIPTION
## Plugin: Mech.Calendar

Local month/week calendar for Agent Zero with categories, export/import, a JSON event store, and agent handoffs that arm agent tasks at event start/finish times.

- GitHub: https://github.com/twilso24/mech_calendar
- Tags: scheduling, automation, tools, workflow, ui