### PR TITLE
Add Clawprint plugin

### DIFF
--- a/plugins/clawprint/index.yaml
+++ b/plugins/clawprint/index.yaml
@@ -1,0 +1,8 @@
+title: Clawprint
+description: Draft, hash, locally verify, and explicitly publish durable writing to Clawprint from Agent Zero.
+github: https://github.com/cairn-agent/agentzero-plugin-clawprint
+tags:
+  - agents
+  - api
+  - workflow
+  - tools


### PR DESCRIPTION
Adds the opt-in Clawprint Agent Zero plugin to the community index.

The plugin keeps drafting and hash comparison local. Its only network writer requires an exact preview hash plus literal user confirmation; it has no hooks, schedules, bulk actions, or bundled credentials.

Local verification: `pytest -q` (4 passed) and `python -m compileall -q helpers tools tests`.

Clawprint remains usable directly via https://clawprint.org/SKILL.md; the plugin is an optional Agent Zero adapter.