### PR TITLE
Update A0 Self-Improvement to 2.1.1

### DIFF
--- a/plugins/dspy_rlm/index.yaml
+++ b/plugins/dspy_rlm/index.yaml
@@ -1,5 +1,5 @@
 title: A0 Self-Improvement
-description: Improves Agent Zero with RLM and DSPy GEPA proposals, comparative live canaries, signed automatic promotion, post-promotion monitoring, and rollback.
+description: A0 Self-Improvement 2.1.1 fixes metadata-only candidate evidence and skips empty RLM calls, with governed replay, canaries, signed promotion, monitoring, and rollback.
 github: https://github.com/TerminallyLazy/a0-self-improvement
 tags:
   - llm


### PR DESCRIPTION
Update the A0 Self-Improvement listing for version 2.1.1: metadata-only trace classification now feeds candidate search correctly, and empty evidence partitions no longer invoke RLM models.

The version lives in the source plugin manifest; this index retains the supported schema and updates the release description. Source release: https://github.com/TerminallyLazy/a0-self-improvement (2.1.1).
