### PR TITLE
Clarify File Browser SSH access compatibility and tags

### DIFF
--- a/plugins/file_browser_ssh/index.yaml
+++ b/plugins/file_browser_ssh/index.yaml
@@ -1,7 +1,8 @@
 title: File Browser SSH access
-description: Connect SFTP folders to Files with pinned SSH server identities, instance keys, per-connection permissions and shared Editor support. Preview requiring the File Browser connection provider interface v1.
+description: Connect SFTP folders to Files with pinned SSH server identities, instance keys, per-connection permissions and shared Editor support. Requires Agent Zero v2.12 or later.
 github: https://github.com/3clyp50/a0-file-browser-ssh
 tags:
   - files
+  - file-browser
   - storage
   - integration


### PR DESCRIPTION
State the user-facing requirement as **Agent Zero v2.12 or later**, matching the updated plugin README, and add `file-browser` alongside the existing `files` tag for discovery.

Only this plugin's Index metadata changes. Validated with the current Plugin Index validator against the committed range.
