### PR TITLE
Clarify File Browser WebDAV access compatibility and tags

### DIFF
--- a/plugins/file_browser_webdav/index.yaml
+++ b/plugins/file_browser_webdav/index.yaml
@@ -1,7 +1,8 @@
 title: File Browser WebDAV access
-description: Connect WebDAV folders over verified HTTPS with per-connection permissions, conditional saves and shared Editor support. Preview requiring the File Browser connection provider interface v1.
+description: Connect WebDAV folders over verified HTTPS with per-connection permissions, conditional saves and shared Editor support. Requires Agent Zero v2.12 or later.
 github: https://github.com/3clyp50/a0-file-browser-webdav
 tags:
   - files
+  - file-browser
   - storage
   - integration


### PR DESCRIPTION
State the user-facing requirement as **Agent Zero v2.12 or later**, matching the updated plugin README, and add `file-browser` alongside the existing `files` tag for discovery.

Only this plugin's Index metadata changes. Validated with the current Plugin Index validator against the committed range.
