### PR TITLE
Clarify File Browser SMB 3 for NAS compatibility and tags

### DIFF
--- a/plugins/file_browser_smb/index.yaml
+++ b/plugins/file_browser_smb/index.yaml
@@ -1,7 +1,8 @@
 title: File Browser SMB 3 for NAS
-description: Browse encrypted SMB 3 NAS shares in Files with signed sessions, explicit credentials and per-connection permissions. Preview requiring the File Browser connection provider interface v1.
+description: Browse encrypted SMB 3 NAS shares in Files with signed sessions, explicit credentials and per-connection permissions. Requires Agent Zero v2.12 or later.
 github: https://github.com/3clyp50/a0-file-browser-smb
 tags:
   - files
+  - file-browser
   - storage
   - integration


### PR DESCRIPTION
State the user-facing requirement as **Agent Zero v2.12 or later**, matching the updated plugin README, and add `file-browser` alongside the existing `files` tag for discovery.

Only this plugin's Index metadata changes. Validated with the current Plugin Index validator against the committed range.
