### PR TITLE
Clarify File Browser S3 access compatibility and tags

### DIFF
--- a/plugins/file_browser_s3/index.yaml
+++ b/plugins/file_browser_s3/index.yaml
@@ -1,7 +1,8 @@
 title: File Browser S3 access
-description: Browse S3 buckets and prefixes in Files with explicit credentials, per-connection permissions and conditional object saves. Preview requiring the File Browser connection provider interface v1.
+description: Browse S3 buckets and prefixes in Files with explicit credentials, per-connection permissions and conditional object saves. Requires Agent Zero v2.12 or later.
 github: https://github.com/3clyp50/a0-file-browser-s3
 tags:
   - files
+  - file-browser
   - storage
   - integration


### PR DESCRIPTION
State the user-facing requirement as **Agent Zero v2.12 or later**, matching the updated plugin README, and add `file-browser` alongside the existing `files` tag for discovery.

Only this plugin's Index metadata changes. Validated with the current Plugin Index validator against the committed range.
