### PR TITLE
Update A0 Self-Improvement to 2.3.1

### DIFF
--- a/plugins/dspy_rlm/index.yaml
+++ b/plugins/dspy_rlm/index.yaml
@@ -1,5 +1,5 @@
 title: A0 Self-Improvement
-description: A0 Self-Improvement 2.3.0 adds outcome-aware learning, failure-prioritized optimization, and learning opportunities, with governed replay, canaries, promotion, monitoring, and rollback.
+description: A0 Self-Improvement 2.3.1 adds a native Agent Zero interface with light/dark themes, outcome-aware learning, and failure-prioritized optimization, with governed replay, canaries, promotion, monitoring, and rollback.
 github: https://github.com/TerminallyLazy/a0-self-improvement
 tags:
   - llm

--- a/plugins/dspy_rlm/index.yaml
+++ b/plugins/dspy_rlm/index.yaml
@@ -1,5 +1,5 @@
 title: A0 Self-Improvement
-description: A0 Self-Improvement 2.2.0 adds learning-health diagnostics, explicit GEPA evaluation budgets, and reliable prompt optimization, with governed replay, canaries, promotion, monitoring, and rollback.
+description: A0 Self-Improvement 2.3.0 adds outcome-aware learning, failure-prioritized optimization, and learning opportunities, with governed replay, canaries, promotion, monitoring, and rollback.
 github: https://github.com/TerminallyLazy/a0-self-improvement
 tags:
   - llm

--- a/plugins/dspy_rlm/index.yaml
+++ b/plugins/dspy_rlm/index.yaml
@@ -1,5 +1,5 @@
 title: A0 Self-Improvement
-description: A0 Self-Improvement 2.1.1 fixes metadata-only candidate evidence and skips empty RLM calls, with governed replay, canaries, signed promotion, monitoring, and rollback.
+description: A0 Self-Improvement 2.2.0 adds learning-health diagnostics, explicit GEPA evaluation budgets, and reliable prompt optimization, with governed replay, canaries, promotion, monitoring, and rollback.
 github: https://github.com/TerminallyLazy/a0-self-improvement
 tags:
   - llm


### PR DESCRIPTION
Update A0 Self-Improvement's catalog entry for 2.3.1, including native Agent Zero styling with light and dark themes, outcome-aware learning, and failure-prioritized optimization.

The runtime version is bumped in the plugin source manifest, package metadata, and lockfile. The catalog schema has no version field; this announcement identifies the current update in the description.

Source: https://github.com/TerminallyLazy/a0-self-improvement/pull/16. Source CI passes Python 3.12–3.14; the dashboard and settings were checked in both live themes on Agent Zero. The source PR is merged; this catalog PR is ready for upstream review.
