### PR TITLE
Update Semantic Review Loop to 1.2.0

### DIFF
--- a/plugins/sem_review_loop/index.yaml
+++ b/plugins/sem_review_loop/index.yaml
@@ -1,5 +1,5 @@
 title: Semantic Review Loop
-description: Adds local semantic code review for Agent Zero with full working-tree coverage, guided MCP tools, entity-level changes, bounded repair, and project-scoped lessons.
+description: Adds local semantic code review with an Agent Zero-native interface, automatically connected MCP tools, live entity-level changes, visible review findings, bounded repair, and useful project-scoped lessons.
 github: https://github.com/TerminallyLazy/sem-review-loop-agent-zero
 tags:
   - development


### PR DESCRIPTION
Refresh the Semantic Review Loop listing for version 1.2.0, now available on the plugin repository's main branch. The update adds an Agent Zero-native interface, automatic MCP connection and recovery, working-tree refresh, readable review findings, and useful optional lessons.

The plugin version is 1.2.0 in its root plugin.yaml; the marketplace state generator reads that version from the source repository. Plugin release: https://github.com/TerminallyLazy/sem-review-loop-agent-zero/pull/1 (merged).

Validation: the plugin's 626-test suite passed with the real pinned sem binary, plus live browser and model-backed review acceptance. This PR changes only the Semantic Review Loop listing and triggers its generated index refresh.
