### PR TITLE
Update Tree Ring Memory lifecycle integration to 3.4.1

### DIFF
--- a/plugins/tree_ring_memory/index.yaml
+++ b/plugins/tree_ring_memory/index.yaml
@@ -1,5 +1,5 @@
 title: Tree Ring Memory
-description: Tree Ring Memory 3.4.0 integrates Agent Zero with bundled Tree Ring 0.15.5, native receipt-backed lifecycle recall, bounded agent-mediated automatic capture, persistent project-level writer identity, and shared multi-agent memory.
+description: Tree Ring Memory 3.4.1 integrates Agent Zero with bundled Tree Ring 0.15.7, native receipt-backed cross-session lifecycle recall, bounded agent-mediated automatic capture, persistent project-level writer identity, and shared multi-agent memory.
 github: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero
 tags:
   - memory


### PR DESCRIPTION
Update Tree Ring Memory's existing listing to released plugin 3.4.1, which bundles CLI 0.15.7 and includes native receipt-backed startup recall across sessions and bounded agent-mediated capture.

Release: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero/releases/tag/v3.4.1
Plugin integration: https://github.com/TerminallyLazy/tree-ring-memory-agent-zero/pull/14
Core fixes: https://github.com/TerminallyLazy/Tree-Ring-Memory/pull/60 and https://github.com/TerminallyLazy/Tree-Ring-Memory/pull/62

Both Linux binaries have verified source provenance and checksums. The plugin's full suite passed in the Agent Zero framework runtime (143 tests), and its package CI passes. This change updates only the existing description; the repository URL and tags are unchanged.
