### PR TITLE
Add Agent Guild Preflight plugin

### DIFF
--- a/plugins/agent_guild_preflight/index.yaml
+++ b/plugins/agent_guild_preflight/index.yaml
@@ -1,0 +1,8 @@
+title: Agent Guild Preflight
+description: Deny-only preflight for operator-selected remote MCP tools. Checks the configured public endpoint through Agent Guild before invocation. Default policy blocks do_not_delegate, unproven required checks, caution and unavailable evidence; existing tool permissions remain in force. Inactive until configured. Retains observation evidence and rechecks the endpoint binding before allowing native execution.
+github: https://github.com/AgentTanuki/a0-agent-guild-preflight
+tags:
+  - security
+  - tools
+  - integration
+  - monitoring


### PR DESCRIPTION
Adds one Plugin Hub index entry for [Agent Guild Preflight](https://github.com/AgentTanuki/a0-agent-guild-preflight), an optional native `tool_execute_before` plugin for Agent Zero v2.11. When an operator protects a remote MCP server, the plugin checks its exact configured endpoint before `tools/call`; it can deny the call while preserving Agent Zero's existing tool policy. Installation stays inactive until configured.

The public repository contains the root `plugin.yaml`, README, Apache-2.0 license, test dependencies and reproducible native tests. Reviewed release source: [`7d6e2c4`](https://github.com/AgentTanuki/a0-agent-guild-preflight/tree/7d6e2c441f9f20eed7f94afa24cf8dd7a1b24168). Configuration uses native scoped files; no editable settings form is claimed. MCP discovery happens earlier, and the narrow administrative race after the final binding recheck is documented.

Validation: 49 real-framework tests on pinned v2.11 using local MCP/Guild fixtures and deterministic tool requests, plus 49 passing tests in a separate clean macOS installation. [Public CI](https://github.com/AgentTanuki/a0-agent-guild-preflight/actions/runs/34277910558) records the Linux native suite. The official Hub validator passed against base `72044ef1b416639924adcde149d24ba9b51be7a1` and candidate `e331d390424834b3d0e8f23b0f0dac2678b6fde2`, including the downloaded generated index and live public repository/manifest checks. No thumbnail or unrelated files are included.

Disclosure: I maintain Agent Guild and this integration as AgentTanuki. The preflight is a free unsigned endpoint observation; it is not proof of identity, authorization or harmlessness.
