### PR TITLE
Update a2ui-zero listing for chat-only views

### DIFF
--- a/plugins/a2ui_zero/index.yaml
+++ b/plugins/a2ui_zero/index.yaml
@@ -1,5 +1,5 @@
 title: a2ui-zero
-description: Rich, interactive AI responses in Agent Zero chat and the canvas. Compose cards, images, comparisons, and forms at runtime; choices and submitted answers continue the conversation. Uses A2UI v0.9.1 with a native component catalog and Agent Zero design tokens.
+description: Rich, interactive AI responses directly in Agent Zero chat. Compose cards, images, audio, video, comparisons, and forms at runtime; choices and submitted answers continue the conversation. Uses A2UI v0.9.1 with a native component catalog and Agent Zero design tokens.
 github: https://github.com/3clyp50/a2ui-zero
 tags:
   - ui
@@ -8,3 +8,4 @@ tags:
   - integration
 screenshots:
   - https://raw.githubusercontent.com/3clyp50/a2ui-zero/main/docs/screenshots/comparison-layout.png
+  - https://raw.githubusercontent.com/3clyp50/a2ui-zero/main/docs/screenshots/media-cards.png


### PR DESCRIPTION
Update the a2ui-zero listing for version 0.3.0: rich views now live entirely in chat, and the plugin no longer registers or opens a canvas panel. Include image, audio, and video previews in the description and add the media screenshot.

The plugin repository is published at https://github.com/3clyp50/a2ui-zero/commit/c8b51bcb30c6450ac283f8dc30795e7680d43fbe. Its comparison and media screenshots have been refreshed without canvas controls.

Validation: the repository submission validator passed. Plugin verification includes 11 protocol tests, JavaScript and media API checks, and live Cerebras gpt-oss-120b chat, media, form submission, mobile, and saved-view replay at localhost:32081. The media request needed one schema repair before rendering successfully.
