### PR TITLE
feat: add chat_jumper

### DIFF
--- a/plugins/chat_jumper/index.yaml
+++ b/plugins/chat_jumper/index.yaml
@@ -1,0 +1,7 @@
+title: Chat Jumper
+description: Keyboard navigation between chats. Ctrl+K opens a fuzzy quick switcher showing your most recent chats with number badges, Alt+1..9 jumps straight to the Nth most recent chat, and Ctrl+backtick flips back to the last chat. Type to filter chats by name or topic with fuzzy subsequence matching. Pure frontend, no backend, no settings.
+github: https://github.com/glatinone/chat-jumper
+tags:
+  - automation
+  - workflow
+  - tools


### PR DESCRIPTION
## Plugin: Chat Jumper

Keyboard navigation between Agent Zero chats. Ctrl+K opens a fuzzy quick switcher with numbered recency badges, Alt+1..9 jumps to the Nth most recent chat, Ctrl+backtick flips to the last chat.

- GitHub: https://github.com/glatinone/chat-jumper
- Tags: automation, workflow, tools

Pure frontend webui extension: no backend handlers, no settings, no outbound network calls. MRU list is stored in the browser's localStorage.