### PR TITLE
feat: add chat_status_lights

### DIFF
--- a/plugins/chat_status_lights/index.yaml
+++ b/plugins/chat_status_lights/index.yaml
@@ -1,0 +1,7 @@
+title: Chat Status Lights
+description: Colored status dots next to sidebar chat titles. Blue pulse while the agent runs, red when a chat ended with an error, yellow when an action waits for your approval (with the Human Approval Gate plugin), green for finished chats you have not opened. One glance tells you which chats need attention. Pure frontend plus one tiny status API, works standalone.
+github: https://github.com/glatinone/chat-status-lights
+tags:
+  - ui
+  - productivity
+  - agents


### PR DESCRIPTION
## Plugin: Chat Status Lights

Colored status dots next to sidebar chat titles: blue pulse (running), red (last turn ended in error), yellow (action awaiting your approval, via the Human Approval Gate plugin), green (finished, not yet opened). Priority ranking when multiple states apply.

- GitHub: https://github.com/glatinone/chat-status-lights
- Tags: ui, productivity, agents

Pure frontend webui extension plus one small status API that scans chat logs for error entries after the last response. No core modifications, no secrets, no outbound network calls. Works standalone; the yellow state simply never appears without the approval gate plugin.